### PR TITLE
Nullable update columns

### DIFF
--- a/pkgIndex.tcl.in
+++ b/pkgIndex.tcl.in
@@ -1,3 +1,3 @@
 package ifneeded Pgtcl @PACKAGE_VERSION@  [list load [file join $dir @PKG_LIB_FILE@]]
-package ifneeded sc_postgres 1.2 \
+package ifneeded sc_postgres 1.3 \
     [list source [file join $dir postgres-helpers.tcl]]

--- a/postgres-helpers.tcl
+++ b/postgres-helpers.tcl
@@ -73,7 +73,7 @@ proc gen_insert_from_array {tableName arrayName} {
 # gen_sql_update_from_array - return a sql update statement based on the
 #   contents of an array and a list of key fields
 #
-proc gen_update_from_array {tableName arrayName keyFields} {
+proc gen_update_from_array {tableName arrayName keyFields {nullableColumns ""}} {
     upvar $arrayName array
 
     set result "update $tableName set "
@@ -84,6 +84,12 @@ proc gen_update_from_array {tableName arrayName keyFields} {
 	    continue
 	}
 	append result "$element = [pg_quote $array($element)], "
+    }
+
+    foreach element $nullableColumns {
+	if {![info exists array($element)]} {
+	    append result "$element = NULL, "
+	}
     }
     set result "[string range $result 0 end-2] where ("
 
@@ -274,3 +280,4 @@ proc res_dont_care {res} {
 
 }
 
+# vim: set ts=8 sw=4 sts=4 noet :

--- a/postgres-helpers.tcl
+++ b/postgres-helpers.tcl
@@ -14,7 +14,7 @@
 # Copyright (C) 2004 Superconnect, Ltd.
 #  Berkeley copyright as above.
 #
-# Copyright (C) 2005-2015 FlightAware, LLC
+# Copyright (C) 2005-2017 FlightAware, LLC
 #  Berkeley copyright as above.
 #
 
@@ -22,7 +22,7 @@
 # postgres interface stuff
 #
 
-package provide sc_postgres 1.2
+package provide sc_postgres 1.3
 
 package require Tclx
 package require Pgtcl


### PR DESCRIPTION
add optional nullableColumns argument to gen_update_from_array.

Columns named in the nullableColumns list will be explicitly set to null in the update statement if there is no corresponding value in the array of column-value pairs.

version bump for sc_postgres to 1.3