### PR TITLE
Fix use-after-free when disconnecting inside pg_select body

### DIFF
--- a/generic/pgtclCmds.c
+++ b/generic/pgtclCmds.c
@@ -3033,6 +3033,11 @@ Pg_select(ClientData cData, Tcl_Interp *interp, int objc, Tcl_Obj *CONST objv[])
 		}
 	}
 
+	// Register on the connection channel to hold it open (eg, in case a user
+	// issues a pg_disconnect inside the select).
+	Tcl_Channel conn_chan = Tcl_GetChannel(interp, connString, 0);
+	Tcl_RegisterChannel(NULL, conn_chan);
+
 	// At this point we no longer need these. Zap them so we don't have to worry about them
 	// in the big loop.
 	if(paramValues) {
@@ -3223,6 +3228,8 @@ Pg_select(ClientData cData, Tcl_Interp *interp, int objc, Tcl_Obj *CONST objv[])
 
 	if(tuplesVarObj)
 	    Tcl_UnsetVar(interp, Tcl_GetString(tuplesVarObj), 0);
+
+	Tcl_UnregisterChannel(NULL, conn_chan);
 
 	Tcl_UnsetVar(interp, varNameString, 0);
 


### PR DESCRIPTION
In Pgtcl 2.6.1, making a`pg_select` query on multiple rows containing nulls, and disconnecting inside the `pg_select` body, can cause the reuse of already-freed memory, potentially leading to a segfault. Note that if `-withoutnulls` is supplied, this does not happen, since the reuse occurs [here](https://github.com/flightaware/Pgtcl/blob/d2eec68ec0e6aed5b9bd4e10e987cb63656ca2cb/generic/pgtclCmds.c#L3152). 

Something like

```
pg_select $::db "SELECT (some multi-row query with nulls)" row {
    pg_disconnect $::db
    set ::db [pg_connect -connlist [array get ::dbSettings]]
}
```

should trigger the bug. (If you're interested, I have a more FlightAware-specific test case that causes this reliably on one of our servers.)

This PR modifies `Pg_select()` so that it registers/unregisters on the channel associated with the database connection, preventing `PgDelConnectionId()` from freeing the connection ID in use until `Pg_select()` completes.

I saw this bug on FreeBSD 11.2-RELEASE-p4, using Tcl 8.6.8.