### PR TITLE
Allow pg_exec to accept SQL statements starting with a comment.

### DIFF
--- a/generic/pgtclCmds.c
+++ b/generic/pgtclCmds.c
@@ -707,7 +707,7 @@ Pg_exec(ClientData cData, Tcl_Interp *interp, int objc, Tcl_Obj *CONST objv[])
 
 	for(index = 1; index < objc && nextPositionalArg != EXEC_ARGS; index++) {
 	    char *arg = Tcl_GetString(objv[index]);
-	    if (arg[0] == '-') {
+	    if (arg[0] == '-' && arg[1] != '-') { // a legal SQL statement can start with "--"
 		if(strcmp(arg, "-paramarray") == 0) {
 		    index++;
 		    paramArrayName = Tcl_GetString(objv[index]);
@@ -1821,7 +1821,7 @@ Pg_execute(ClientData cData, Tcl_Interp *interp, int objc, Tcl_Obj *CONST objv[]
 	while (i < objc)
 	{
 		arg = Tcl_GetString(objv[i]);
-		if (arg[0] != '-')
+		if (arg[0] != '-' || arg[1] == '-')
                 {
 		    break;
                 }
@@ -1841,8 +1841,6 @@ Pg_execute(ClientData cData, Tcl_Interp *interp, int objc, Tcl_Obj *CONST objv[]
 			array_varname = Tcl_GetString(objv[i++]);
 			continue;
 		}
-
-		arg = Tcl_GetString(objv[i]);
 
 		if (strcmp(arg, "-oid") == 0)
 		{

--- a/tests/pgtcl.test
+++ b/tests/pgtcl.test
@@ -775,6 +775,33 @@ test pgtcl-6.5 {pg_select error code} -body {
 #
 #
 #
+test pgtcl-6.6 {using pg_exec with statement starting with a comment} -body {
+
+    unset -nocomplain res
+
+    set conn [pg::connect -connlist [array get ::conninfo]]
+
+    set res [$conn exec {-- something about this statement here
+
+			 SELECT relname
+                           FROM Pg_class
+                          WHERE relname LIKE 'pg_%'
+                       ORDER BY relname
+                          LIMIT 5}]
+
+    set results [pg::result $res -list]
+
+    pg_result $res -clear
+
+    pg_disconnect $conn
+
+    lsort $results
+
+} -result [list pg_aggregate pg_aggregate_fnoid_index pg_am pg_am_name_index pg_am_oid_index]
+
+#
+#
+#
 test pgtcl-7.1 {using pg_select} -body {
 
     unset -nocomplain res


### PR DESCRIPTION
Duplicated logic from pg_select and added test case.