### PR TITLE
Update to new (ish) copy API

### DIFF
--- a/configure.in
+++ b/configure.in
@@ -19,7 +19,7 @@ dnl	to configure the system for the local environment.
 # so you can encode the package version directly into the source files.
 #-----------------------------------------------------------------------
 
-AC_INIT([pgtcl], [2.6.3])
+AC_INIT([pgtcl], [2.6.4])
 
 #-----
 # Version with patch stripped

--- a/generic/pgtcl.c
+++ b/generic/pgtcl.c
@@ -97,6 +97,7 @@ static PgCmd commands[] = {
     {"pg_dbinfo", "::pg::dbinfo", Pg_dbinfo,2},
     {"pg_getdata", "::pg::getdata", Pg_getdata,2},
     {"pg_sql", "::pg::sql", Pg_sql,2},
+    {"pg_copy_complete", "::pg::copy_complete", Pg_copy_complete, 3},
 #ifdef HAVE_SQLITE3
     {"pg_sqlite", "::pg::sqlite", Pg_sqlite, 3},
 #endif

--- a/generic/pgtclId.c
+++ b/generic/pgtclId.c
@@ -601,8 +601,7 @@ PgConnCmd(ClientData cData, Tcl_Interp *interp, int objc, Tcl_Obj *CONST objv[])
         }
 	case CONNDEFAULTS:
 	{
-            returnCode = Pg_conndefaults(cData, interp, 1, objvx);
-	    break;
+            return Pg_conndefaults(cData, interp, 1, objvx);
 	}
 	
 	case SET_SINGLE_ROW_MODE:

--- a/generic/pgtclId.c
+++ b/generic/pgtclId.c
@@ -94,6 +94,12 @@ PgInputProc(DRIVER_INPUT_PROTO)
 	  }
 	}
 
+	/* Should never happen */
+	if(avail < 0) {
+		*errorCodePtr = EIO;
+		return -1;
+	}
+
 	if(bufPtr) {
 		memcpy (buf, bufPtr, avail);
 		PQfreemem(bufPtr);

--- a/generic/pgtclId.c
+++ b/generic/pgtclId.c
@@ -1578,9 +1578,9 @@ Pg_copy_complete(ClientData cData, Tcl_Interp *interp, int objc,
 		return TCL_ERROR;
 
 	if (PgEndCopy(connid, &errorCode, 1) == -1) {
-		char *errorMessage = "I/O Error"
+		char *errorMessage = "I/O Error";
 		if(errorCode == EBUSY) {
-			errorMessage = "Busy"
+			errorMessage = "Busy";
 		}
 		Tcl_SetObjResult(interp, Tcl_NewStringObj(errorMessage, -1));
 		return TCL_ERROR;

--- a/generic/pgtclId.c
+++ b/generic/pgtclId.c
@@ -108,6 +108,7 @@ PgOutputProc(DRIVER_OUTPUT_PROTO)
 	Pg_ConnectionId *connid;
 	PGconn	   *conn;
 	int         endcopy = 0;
+	int         writeLen;
 
 	connid = (Pg_ConnectionId *) cData;
 	conn = connid->conn;
@@ -119,17 +120,19 @@ PgOutputProc(DRIVER_OUTPUT_PROTO)
 		return -1;
 	}
 
+	writeLen = bufSize;
+
 	/*
 	 * This assumes Tcl script will write the terminator line in a single
 	 * operation; maybe not such a good assumption?
 	 */
-	if (bufSize >= 3 && strncmp(&buf[bufSize - 3], "\\.\n", 3) == 0)
+	if (writeLen >= 3 && strncmp(&buf[writeLen - 3], "\\.\n", 3) == 0)
 	{
-		bufSize -= 3; // Don't write the terminator using the new API
+		writeLen -= 3; // Don't write the terminator using the new API
 		endcopy = 1;
 	}
 
-	if (PQputCopyData(conn, buf, bufSize) < 0)
+	if (PQputCopyData(conn, buf, writeLen) < 0)
 	{
 		*errorCodePtr = EIO;
 		return -1;

--- a/generic/pgtclId.c
+++ b/generic/pgtclId.c
@@ -126,7 +126,7 @@ PgOutputProc(DRIVER_OUTPUT_PROTO)
 	if (bufSize >= 3 && strncmp(&buf[bufSize - 3], "\\.\n", 3) == 0)
 	{
 		bufSize -= 3; // Don't write the terminator using the new API
-		endcopy - 1;
+		endcopy = 1;
 	}
 
 	if (PQputCopyData(conn, buf, bufSize) < 0)

--- a/generic/pgtclId.c
+++ b/generic/pgtclId.c
@@ -306,7 +306,11 @@ PgConnCmd(ClientData cData, Tcl_Interp *interp, int objc, Tcl_Obj *CONST objv[])
         "sendquery_prepared",  "null_value_string", "version", 
         "protocol", "param", "backendpid", "socket", 
 	"conndefaults",  "set_single_row_mode", "is_busy", "blocking",
-	"cancel_request", (char *)NULL
+	"cancel_request",
+#ifdef HAVE_SQLITE3
+	"sqlite"
+#endif
+	(char *)NULL
     };
 
     enum options
@@ -319,7 +323,10 @@ PgConnCmd(ClientData cData, Tcl_Interp *interp, int objc, Tcl_Obj *CONST objv[])
 	SENDQUERY_PREPARED, NULL_VALUE_STRING, VERSION, 
 	PROTOCOL, PARAM, BACKENDPID, SOCKET,
 	CONNDEFAULTS, SET_SINGLE_ROW_MODE, ISBUSY, BLOCKING,
-	CANCELREQUEST
+	CANCELREQUEST,
+#ifdef HAVE_SQLITE3
+	SQLITE3
+#endif
     };
 
     if (objc == 1 || objc > 25)
@@ -622,6 +629,14 @@ PgConnCmd(ClientData cData, Tcl_Interp *interp, int objc, Tcl_Obj *CONST objv[])
             returnCode = Pg_cancelrequest(cData, interp, objc, objvx);
 	    break;
 	}
+#ifdef HAVE_SQLITE3
+	case SQLITE3:
+	{
+            objvx[1] = Tcl_NewStringObj(connid->id, -1);
+            returnCode = Pg_sqlite(cData, interp, objc, objvx);
+	    break;
+	}
+#endif
     }
 	Tcl_DecrRefCount(objvx[idx]);
 	return returnCode;

--- a/generic/pgtclId.h
+++ b/generic/pgtclId.h
@@ -125,3 +125,6 @@ extern void PgDelCmdHandle(ClientData cData);
 extern void PgDelResultHandle(ClientData cData);
 
 extern Tcl_ChannelType Pg_ConnType;
+
+extern int Pg_copy_complete(
+  ClientData cData, Tcl_Interp *interp, int objc, Tcl_Obj *CONST objv[]);

--- a/tests/pgtcl.test
+++ b/tests/pgtcl.test
@@ -1116,4 +1116,141 @@ test pgtcl-9.5 {dbinfo socket} -body {
 
 } -result [list 1 1]
 
+#
+# COPY in/out tests
+#
+test pgtcl-10.1 {copy in} -body {
+    unset -nocomplain res
+
+    set conn [pg::connect -connlist [array get ::conninfo]]
+
+    set r [pg_exec $conn {
+    CREATE TEMPORARY TABLE test1011 (
+	key text primary key,
+	val text
+    );
+    }]
+    set ok 1
+    if {[pg_result $r -status] ne "PGRES_COMMAND_OK"} {
+	set ok 0
+	set result "ERROR [pg_result $r -status] [pg_result $r -error]"
+    }
+    pg_result $r -clear
+
+    if {$ok} {
+	set r [pg_exec $conn "COPY test1011 FROM stdin with DELIMITER as '\t';"]
+	if {"[pg_result $r -status]" ne "PGRES_COPY_IN"} {
+	    set ok 0
+	    set result "ERROR [pg_result $r -status] [pg_result $r -error]"
+	} else {
+	    puts $conn "name	batfink"
+	    puts $conn "wings	steel"
+	    puts $conn "type	superhero"
+	    puts $conn "studio	Hal Seeger Studios"
+	    puts $conn "\\."
+	}
+    }
+
+    if {$ok} {
+	set result {}
+	pg_select $conn -nodotfields "select key,val from test1011 ORDER BY key;" row {
+	    lappend result [array get row]
+	}
+    }
+
+    ::pg::disconnect $conn
+
+    set result
+} -result {{key name val batfink} {key studio val {Hal Seeger Studios}} {key type val superhero} {key wings val steel}}
+
+#
+#
+#
+test pgtcl-10.2 {copy in new API} -body {
+    unset -nocomplain res
+
+    set conn [pg::connect -connlist [array get ::conninfo]]
+
+    set r [pg_exec $conn {
+    CREATE TEMPORARY TABLE test1011 (
+	key text primary key,
+	val text
+    );
+    }]
+    set ok 1
+    if {[pg_result $r -status] ne "PGRES_COMMAND_OK"} {
+	set ok 0
+	set result "ERROR [pg_result $r -status] [pg_result $r -error]"
+    }
+    pg_result $r -clear
+
+    if {$ok} {
+	set r [pg_exec $conn "COPY test1011 FROM stdin with DELIMITER as '\t';"]
+	if {"[pg_result $r -status]" ne "PGRES_COPY_IN"} {
+	    set ok 0
+	    set result "ERROR [pg_result $r -status] [pg_result $r -error]"
+	} else {
+	    puts $conn "name	batfink"
+	    puts $conn "wings	steel"
+	    puts $conn "type	superhero"
+	    puts $conn "studio	Hal Seeger Studios"
+	    $conn copy_complete
+	}
+    }
+
+    if {$ok} {
+	set result {}
+	pg_select $conn -nodotfields "select key,val from test1011 ORDER BY key;" row {
+	    lappend result [array get row]
+	}
+    }
+
+    ::pg::disconnect $conn
+
+    set result
+} -result {{key name val batfink} {key studio val {Hal Seeger Studios}} {key type val superhero} {key wings val steel}}
+
+#
+#
+#
+test pgtcl-10.3 {copy in new API} -body {
+    unset -nocomplain res
+
+    set conn [pg::connect -connlist [array get ::conninfo]]
+
+    set r [pg_exec $conn {
+    CREATE TEMPORARY TABLE test1011 (
+	key text primary key,
+	val text
+    );
+    INSERT INTO test1011 (key, val) VALUES ('name', 'batfink');
+    INSERT INTO test1011 (key, val) VALUES ('wings', 'steel');
+    INSERT INTO test1011 (key, val) VALUES ('type', 'superhero');
+    INSERT INTO test1011 (key, val) VALUES ('studio', 'Hal Seeger Studios');
+    }]
+    set ok 1
+    if {[pg_result $r -status] ne "PGRES_COMMAND_OK"} {
+	set ok 0
+	set result "ERROR [pg_result $r -status] [pg_result $r -error]"
+    }
+    pg_result $r -clear
+
+    if {$ok} {
+	set r [pg_exec $conn "COPY test1011 TO stdout with DELIMITER as '\t';"]
+	if {"[pg_result $r -status]" eq "PGRES_COPY_OUT"} {
+	    set result {}
+	    while {[gets $conn line]>= 0} {
+		lappend result [split $line "\t"]
+	    }
+	} else {
+	    set result "ERROR [pg_result $r -status] [pg_result $r -error]"
+	}
+	pg_result $r -clear
+	set result [lsort -index 0 $result]
+    }
+    ::pg::disconnect $conn
+
+    set result
+} -result {{name batfink} {studio {Hal Seeger Studios}} {type superhero} {wings steel}}
+
 puts "tests complete"

--- a/tests/pgtcl.test
+++ b/tests/pgtcl.test
@@ -605,9 +605,15 @@ test pgtcl-4.18 {test pg_result -lAttributes} -body {
 
     pg_disconnect $conn
 
-    set stat
+# drop actual type details (oid, size) because they're not stable
 
-} -result [list [list col1 705 -2] [list col2 705 -2]]
+    set names {}
+    foreach tuple $stat {
+	lappend names [lindex $tuple 0]
+    }
+
+    set names
+} -result [list col1 col2]
 
 #
 #

--- a/tests/pgtcl.test
+++ b/tests/pgtcl.test
@@ -1213,7 +1213,7 @@ test pgtcl-10.2 {copy in new API} -body {
 #
 #
 #
-test pgtcl-10.3 {copy in new API} -body {
+test pgtcl-10.3 {copy out} -body {
     unset -nocomplain res
 
     set conn [pg::connect -connlist [array get ::conninfo]]


### PR DESCRIPTION
* Update to new API for existing code base
* Add `$handle copy_complete` as an alternative for `puts $handle "\\."`
* Add tests for copy out and both variants of copy in to test suite
* Fixed existing bug where it could decrement refcount to an object not allocated.