### PR TITLE
Update Pgtcl to use Tcl Utf conversion routines to ensure all SQL passed into Postgres is legal.

### DIFF
--- a/configure.in
+++ b/configure.in
@@ -19,7 +19,7 @@ dnl	to configure the system for the local environment.
 # so you can encode the package version directly into the source files.
 #-----------------------------------------------------------------------
 
-AC_INIT([pgtcl], [2.7.5])
+AC_INIT([pgtcl], [2.7.6])
 
 #-----
 # Version with patch stripped

--- a/generic/pgtcl.c
+++ b/generic/pgtcl.c
@@ -181,8 +181,9 @@ Pgtcl_Init(Tcl_Interp *interp)
 	if (tclversion >= 8.1)
 		Tcl_PutEnv("PGCLIENTENCODING=UNICODE");
 
-	/* register all pgtcl commands */
+	pgtclInitEncoding(interp);
 
+	/* register all pgtcl commands */
 
 	for (cmdPtr = commands; cmdPtr->name != NULL; cmdPtr++) {
 		Tcl_CreateObjCommand(interp, cmdPtr->name, 

--- a/generic/pgtcl.c
+++ b/generic/pgtcl.c
@@ -160,7 +160,7 @@ Pgtcl_Init(Tcl_Interp *interp)
                     * No really good way to do error handling here, since we
                     * don't know how we were loaded
                     */
-                    return FALSE;
+                    return TCL_ERROR;
             }
 
     #endif
@@ -181,7 +181,8 @@ Pgtcl_Init(Tcl_Interp *interp)
 	if (tclversion >= 8.1)
 		Tcl_PutEnv("PGCLIENTENCODING=UNICODE");
 
-	pgtclInitEncoding(interp);
+	if(pgtclInitEncoding(interp) != TCL_OK)
+		return TCL_ERROR;
 
 	/* register all pgtcl commands */
 

--- a/generic/pgtclCmds.c
+++ b/generic/pgtclCmds.c
@@ -241,6 +241,15 @@ tcl_value(char *value)
 #define tcl_value(x) x
 #endif   /* TCL_ARRAYS */
 
+static Tcl_Encoding utf8encoding = NULL;
+
+/*
+ * Initialize utf8encoding
+ */
+void pgtclInitEncoding(Tcl_Interp *interp) {
+	utf8encoding = Tcl_GetEncoding(interp, "utf-8");
+}
+
 /*
  * PGgetvalue()
  *
@@ -796,8 +805,7 @@ Pg_exec(ClientData cData, Tcl_Interp *interp, int objc, Tcl_Obj *CONST objv[])
         }
 
 	Tcl_DString ds;
-	Tcl_Encoding e = Tcl_GetEncoding(interp, "utf-8");
-	char *externalString = Tcl_UtfToExternalDString(e, execString, strlen(execString), &ds);
+	char *externalString = Tcl_UtfToExternalDString(utf8encoding, execString, strlen(execString), &ds);
 
 	/* we could call PQexecParams when nParams is 0, but PQexecParams
 	 * will not accept more than one SQL statement per call, while
@@ -817,7 +825,6 @@ Pg_exec(ClientData cData, Tcl_Interp *interp, int objc, Tcl_Obj *CONST objv[])
 	    }
 	}
 
-	Tcl_FreeEncoding(e);
 	Tcl_DStringFree(&ds);
 
 	connid->sql_count++;

--- a/generic/pgtclCmds.c
+++ b/generic/pgtclCmds.c
@@ -287,6 +287,7 @@ PGgetvalue ( PGresult *result, char *nullString, int tupno, int fieldNumber )
 		return string;
 	}
 
+	// TODO convert from external to utf?
 	/* string is not empty */
 	return tcl_value (string);
 }
@@ -816,6 +817,7 @@ Pg_exec(ClientData cData, Tcl_Interp *interp, int objc, Tcl_Obj *CONST objv[])
 	if (nParams == 0) {
 	    result = PQexec(conn, externalString);
 	} else {
+	    // TODO convert paramvalues from utf to external
 	    result = PQexecParams(conn, externalString, nParams, NULL, paramValues, NULL, NULL, 0);
 	    ckfree ((void *)paramValues);
 	    paramValues = NULL;
@@ -1022,6 +1024,7 @@ Pg_result_foreach(Tcl_Interp *interp, PGresult *result, Tcl_Obj *arrayNameObj, T
 		    }
 
 		    char *string = PQgetvalue (result, tupno, column);
+		    // TODO convert from external to utf
 
 		    if (Tcl_SetVar2(interp, arrayName, columnName, string, (TCL_LEAVE_ERR_MSG)) == NULL) 
 		    {
@@ -1303,8 +1306,8 @@ Pg_result(ClientData cData, Tcl_Interp *interp, int objc, Tcl_Obj *CONST objv[])
 					return TCL_ERROR;
 				}
 
-                /* This will take care of the cleanup */
-                Tcl_DeleteCommandFromToken(interp, resultid->cmd_token);
+				/* This will take care of the cleanup */
+				Tcl_DeleteCommandFromToken(interp, resultid->cmd_token);
 				return TCL_OK;
 			}
 
@@ -1328,7 +1331,7 @@ Pg_result(ClientData cData, Tcl_Interp *interp, int objc, Tcl_Obj *CONST objv[])
 				}
 
 				Tcl_SetObjResult(interp, Tcl_NewStringObj(
-                  PQcmdTuples(result), -1));
+					PQcmdTuples(result), -1));
 				return TCL_OK;
 			}
 
@@ -1460,19 +1463,19 @@ Pg_result(ClientData cData, Tcl_Interp *interp, int objc, Tcl_Obj *CONST objv[])
 
 				if (tupno < 0 || tupno >= PQntuples(result))
 				{
-                    tresult = Tcl_NewStringObj("argument to getTuple cannot exceed ", -1);
-                    Tcl_AppendStringsToObj(tresult, "number of tuples - 1", NULL);
-                    Tcl_SetObjResult(interp, tresult);
-/*
-                    Tcl_AppendStringsToObj(Tcl_GetObjResult(interp),
-                        "argument to getTuple cannot exceed ",
-                        "number of tuples - 1", NULL);
-*/
+					tresult = Tcl_NewStringObj("argument to getTuple cannot exceed ", -1);
+					Tcl_AppendStringsToObj(tresult, "number of tuples - 1", NULL);
+					Tcl_SetObjResult(interp, tresult);
+					/*
+					Tcl_AppendStringsToObj(Tcl_GetObjResult(interp),
+						"argument to getTuple cannot exceed ",
+						"number of tuples - 1", NULL);
+					*/
 					return TCL_ERROR;
 				}
 
 				/* set the result object to be an empty list */
-                resultObj = Tcl_NewListObj(0, NULL);
+				resultObj = Tcl_NewListObj(0, NULL);
 
 				/* build up a return list, Tcl-object-style */
 				for (i = 0; i < PQnfields(result); i++)
@@ -1484,7 +1487,7 @@ Pg_result(ClientData cData, Tcl_Interp *interp, int objc, Tcl_Obj *CONST objv[])
 							   Tcl_NewStringObj(value, -1)) == TCL_ERROR)
 						return TCL_ERROR;
 				}
-                Tcl_SetObjResult(interp, resultObj);
+				Tcl_SetObjResult(interp, resultObj);
 				return TCL_OK;
 			}
 
@@ -1504,8 +1507,8 @@ Pg_result(ClientData cData, Tcl_Interp *interp, int objc, Tcl_Obj *CONST objv[])
 
 				if (tupno < 0 || tupno >= PQntuples(result))
 				{
-                    tresult = Tcl_NewStringObj("argument to tupleArray cannot exceed number of tuples - 1", -1);
-                    Tcl_SetObjResult(interp, tresult);
+					tresult = Tcl_NewStringObj("argument to tupleArray cannot exceed number of tuples - 1", -1);
+					Tcl_SetObjResult(interp, tresult);
 					return TCL_ERROR;
 				}
 
@@ -1535,6 +1538,7 @@ Pg_result(ClientData cData, Tcl_Interp *interp, int objc, Tcl_Obj *CONST objv[])
 						char *string;
 
 						string = PQgetvalue (result, tupno, i);
+						// TODO convert from external to utf
 						if (*string == '\0') {
 							if (PQgetisnull (result, tupno, i)) {
 							   Tcl_UnsetVar2 (interp, arrayName, PQfname(result, i), 0);
@@ -1566,7 +1570,7 @@ Pg_result(ClientData cData, Tcl_Interp *interp, int objc, Tcl_Obj *CONST objv[])
 					Tcl_ListObjAppendElement(interp, resultObj,
 							   Tcl_NewStringObj(PQfname(result, i), -1));
 				}
-                Tcl_SetObjResult(interp, resultObj);
+				Tcl_SetObjResult(interp, resultObj);
 				return TCL_OK;
 			}
 
@@ -1604,7 +1608,7 @@ Pg_result(ClientData cData, Tcl_Interp *interp, int objc, Tcl_Obj *CONST objv[])
 						== TCL_ERROR)
 						return TCL_ERROR;
 				}
-                Tcl_SetObjResult(interp, resultObj);
+				Tcl_SetObjResult(interp, resultObj);
 				return TCL_OK;
 			}
 
@@ -1761,12 +1765,11 @@ Pg_result(ClientData cData, Tcl_Interp *interp, int objc, Tcl_Obj *CONST objv[])
 				if (objc == 3)
 				{
 					if (resultid->nullValueString == NULL || 
-                           *resultid->nullValueString == '\0') {
-
-                        Tcl_SetObjResult(interp, Tcl_NewStringObj("", 0));
+					    *resultid->nullValueString == '\0') {
+						Tcl_SetObjResult(interp, Tcl_NewStringObj("", 0));
 					} else {
-                        Tcl_SetObjResult(interp, 
-                          Tcl_NewStringObj(resultid->nullValueString, -1));
+						Tcl_SetObjResult(interp, 
+							Tcl_NewStringObj(resultid->nullValueString, -1));
 					}
 					return TCL_OK;
 				}
@@ -1787,7 +1790,7 @@ Pg_result(ClientData cData, Tcl_Interp *interp, int objc, Tcl_Obj *CONST objv[])
 
 		default:
 			{
-                Tcl_SetObjResult(interp, Tcl_NewStringObj("Invalid option\n", -1));
+				Tcl_SetObjResult(interp, Tcl_NewStringObj("Invalid option\n", -1));
 				goto Pg_result_errReturn;		/* append help info */
 			}
 	}
@@ -1938,6 +1941,7 @@ Pg_execute(ClientData cData, Tcl_Interp *interp, int objc, Tcl_Obj *CONST objv[]
 	 * Execute the query
 	 */
 	queryString = Tcl_GetString(objv[i++]);
+	// TODO convert from utf to external
 	result = PQexec(conn, queryString);
 	connid->sql_count++;
 
@@ -2006,7 +2010,7 @@ Pg_execute(ClientData cData, Tcl_Interp *interp, int objc, Tcl_Obj *CONST objv[]
 				== TCL_ERROR)
 				return TCL_ERROR;
 
-            Tcl_SetObjResult(interp, resultObj);
+			Tcl_SetObjResult(interp, resultObj);
 			PQclear(result);
 			return TCL_ERROR;
 	}
@@ -2108,6 +2112,7 @@ execute_put_values(Tcl_Interp *interp, const char *array_varname,
 	{
 		fname = PQfname(result, i);
 		value = PGgetvalue(result, nullValueString, tupno, i);
+		// TODO convert from external to UTF
 
 		if (array_varname != NULL)
 		{
@@ -3120,8 +3125,10 @@ Pg_select(ClientData cData, Tcl_Interp *interp, int objc, Tcl_Obj *CONST objv[])
 	{
 		int status;
 
+		// TODO convert from UTF to external
 		// Make the call
 		if (nParams) {
+			// TODO convert params to external
 			status = PQsendQueryParams(conn, queryString, nParams,
 				NULL, paramValues, NULL, NULL, 0);
 		} else {
@@ -3153,8 +3160,10 @@ Pg_select(ClientData cData, Tcl_Interp *interp, int objc, Tcl_Obj *CONST objv[])
 			goto cleanup_params_and_return_error;
 		}
 	} else {
+		// TODO convert from UTF to external
 		// Make the call AND queue up the result.
 		if (nParams) {
+			// TODO convert params to external
 			result = PQexecParams(conn, queryString, nParams,
 				NULL, paramValues, NULL, NULL, 0);
 		} else {
@@ -3303,6 +3312,7 @@ Pg_select(ClientData cData, Tcl_Interp *interp, int objc, Tcl_Obj *CONST objv[])
 					}
 				}
 
+				// TODO convert from external to UTF
 				if (valueObj == NULL) {
 					valueObj = Tcl_NewStringObj(string, -1);
 				}
@@ -3725,6 +3735,7 @@ Pg_sendquery(ClientData cData, Tcl_Interp *interp, int objc,
 	    build_param_array(interp, nParams, &objv[index], &paramValues);
         }
 
+	//TODO convert execString from UTF to external
 	if (nParams == 0) {
 	    status = PQsendQuery(conn, execString);
 	} else {
@@ -3798,6 +3809,7 @@ Pg_sendquery_prepared(ClientData cData, Tcl_Interp *interp, int objc, Tcl_Obj *C
 		return TCL_ERROR;
 	}
 
+	// TODO convert params
 	/* If there are any extra params, allocate paramValues and fill it
 	 * with the string representations of all of the extra parameters
 	 * substituted on the command line.  Otherwise nParams will be 0,
@@ -5267,6 +5279,7 @@ Pg_sql(ClientData cData, Tcl_Interp *interp, int objc,
 	 binValues = (int *)ckalloc (countbin * sizeof (char *));
 
 	 for (param = 0; param < count; param++) {
+		// TODO convert to external
 	     paramValues[param] = Tcl_GetString (elemPtrs[param]);
 	     if (strcmp(paramValues[param], "NULL") == 0)
              {
@@ -5311,6 +5324,7 @@ Pg_sql(ClientData cData, Tcl_Interp *interp, int objc,
        Tcl_IncrRefCount(objv[callback]);
        Tcl_Preserve((ClientData) interp);
 
+	// TODO convert to external
        /* 
         *  invoke function based on type 
         *  of query 
@@ -5329,6 +5343,7 @@ Pg_sql(ClientData cData, Tcl_Interp *interp, int objc,
         }
     } else {
 
+	// TODO convert to external
         if (prepared) {
 	    result = PQexecPrepared(conn, execString, count, paramValues, paramLengths, binValues, binresults);
         } else if (params) {

--- a/generic/pgtclCmds.c
+++ b/generic/pgtclCmds.c
@@ -251,7 +251,6 @@ int pgtclInitEncoding(Tcl_Interp *interp) {
 	utf8encoding = Tcl_GetEncoding(interp, "utf-8");
 	if (utf8encoding != NULL)
 		return TCL_OK;
-	Tcl_SetResult(interp, "Could not initialize encoding utf-8", TCL_STATIC);
 	return TCL_ERROR;
 }
 

--- a/generic/pgtclCmds.c
+++ b/generic/pgtclCmds.c
@@ -702,6 +702,7 @@ void build_param_array(Tcl_Interp *interp, int nParams, Tcl_Obj *CONST objv[], c
 
 	paramValues = (const char **)ckalloc (nParams * sizeof (char *));
 
+	// TODO convert to external
 	for (param = 0; param < nParams; param++) {
 	    paramValues[param] = Tcl_GetString(objv[param]);
 	    if (strcmp(paramValues[param], "NULL") == 0)
@@ -3413,7 +3414,6 @@ Pg_select(ClientData cData, Tcl_Interp *interp, int objc, Tcl_Obj *CONST objv[])
 	return retval;
 }
 
-//HERE//
 /*
  * Test whether any callbacks are registered on this connection for
  * the given relation name.  NB: supplied name must be case-folded already.
@@ -3760,11 +3760,10 @@ Pg_sendquery(ClientData cData, Tcl_Interp *interp, int objc,
 	    build_param_array(interp, nParams, &objv[index], &paramValues);
         }
 
-	//TODO convert execString from UTF to external
 	if (nParams == 0) {
-	    status = PQsendQuery(conn, execString);
+	    status = PQsendQuery(conn, externalString(execString));
 	} else {
-	    status = PQsendQueryParams(conn, execString, nParams, NULL, paramValues, NULL, NULL, 1);
+	    status = PQsendQueryParams(conn, externalString(execString), nParams, NULL, paramValues, NULL, NULL, 1);
 	    if(newExecString) ckfree(newExecString);
 	    ckfree ((void *)paramValues);
 	}
@@ -3833,6 +3832,7 @@ Pg_sendquery_prepared(ClientData cData, Tcl_Interp *interp, int objc, Tcl_Obj *C
 		Tcl_SetResult(interp, "Attempt to query while COPY in progress", TCL_STATIC);
 		return TCL_ERROR;
 	}
+//HERE//
 
 	// TODO convert params
 	/* If there are any extra params, allocate paramValues and fill it
@@ -5349,7 +5349,6 @@ Pg_sql(ClientData cData, Tcl_Interp *interp, int objc,
        Tcl_IncrRefCount(objv[callback]);
        Tcl_Preserve((ClientData) interp);
 
-	// TODO convert to external
        /* 
         *  invoke function based on type 
         *  of query 
@@ -5357,24 +5356,23 @@ Pg_sql(ClientData cData, Tcl_Interp *interp, int objc,
         if (prepared) {
 	    iResult = PQsendQueryPrepared(conn, execString, count, paramValues, paramLengths, binValues, binresults);
         } else if (params) {
-            iResult = PQsendQueryParams(conn, execString, count, NULL, paramValues, paramLengths, binValues, binresults);
+            iResult = PQsendQueryParams(conn, externalString(execString), count, NULL, paramValues, paramLengths, binValues, binresults);
 
         } else {
     
-            iResult = PQsendQuery(conn, execString);
+            iResult = PQsendQuery(conn, externalString(execString));
 /*
             ckfree ((void *)paramValues);
 */
         }
     } else {
 
-	// TODO convert to external
         if (prepared) {
 	    result = PQexecPrepared(conn, execString, count, paramValues, paramLengths, binValues, binresults);
         } else if (params) {
-            result = PQexecParams(conn, execString, count, NULL, paramValues, paramLengths, binValues, binresults);
+            result = PQexecParams(conn, externalString(execString), count, NULL, paramValues, paramLengths, binValues, binresults);
         } else {
-            result = PQexec(conn, execString);
+            result = PQexec(conn, externalString(execString));
             ckfree ((void *)paramValues);
         }
     } /* end if callback */

--- a/generic/pgtclCmds.c
+++ b/generic/pgtclCmds.c
@@ -871,7 +871,7 @@ Pg_exec(ClientData cData, Tcl_Interp *interp, int objc, Tcl_Obj *CONST objv[])
 			Tcl_SetResult(interp, "-variables can not be used with positional or named parameters", TCL_STATIC);
 			return TCL_ERROR;
 		}
-		if (handle_substitutions(interp, execString, &newExecString, &paramValues, &nParams, 1) != TCL_OK) {
+		if (handle_substitutions(interp, execString, &newExecString, &paramValues, &nParams, &paramsBuffer) != TCL_OK) {
 			return TCL_ERROR;
 		}
 		if(nParams)
@@ -3195,7 +3195,7 @@ Pg_select(ClientData cData, Tcl_Interp *interp, int objc, Tcl_Obj *CONST objv[])
 	}
 
 	if (useVariables) {
-		if (handle_substitutions(interp, queryString, &newQueryString, &paramValues, &nParams, 1) != TCL_OK) {
+		if (handle_substitutions(interp, queryString, &newQueryString, &paramValues, &nParams, &paramsBuffer) != TCL_OK) {
 			return TCL_ERROR;
 		}
 		if(nParams)
@@ -3827,13 +3827,13 @@ Pg_sendquery(ClientData cData, Tcl_Interp *interp, int objc,
 			Tcl_SetResult(interp, "-variables can not be used with positional or named parameters", TCL_STATIC);
 			return TCL_ERROR;
 		}
-		if (handle_substitutions(interp, execString, &newExecString, &paramValues, &nParams, 1) != TCL_OK) {
+		if (handle_substitutions(interp, execString, &newExecString, &paramValues, &nParams, &paramsBuffer) != TCL_OK) {
 			return TCL_ERROR;
 		}
 		if(nParams)
 			execString = newExecString;
 		else { // No variables being substituted, fall back to simple code path
-			ckfree(newExecString);
+			ckfree((void *)newExecString);
 			newExecString = NULL;
 			ckfree((void *)paramValues);
 			paramValues = NULL;

--- a/generic/pgtclCmds.c
+++ b/generic/pgtclCmds.c
@@ -258,10 +258,10 @@ void pgtclInitEncoding(Tcl_Interp *interp) {
 /*
  * Convert one utf string at a time to an external string, hiding the DString management.
  */
-char *externalString(char *utfString)
+char *externalString(const char *utfString)
 {
 	static Tcl_DString tmpds;
-	static allocated = 0;
+	static int allocated = 0;
 	if(allocated) Tcl_DStringFree(&tmpds);
 	allocated = 1;
 	return Tcl_UtfToExternalDString(utf8encoding, utfString, -1, &tmpds);
@@ -270,10 +270,10 @@ char *externalString(char *utfString)
 /*
  * Convert one external string at a time to a utf string, hiding the DString management.
  */
-char *utfString(char *externalString)
+char *utfString(const char *externalString)
 {
 	static Tcl_DString tmpds;
-	static allocated = 0;
+	static int allocated = 0;
 	if(allocated) Tcl_DStringFree(&tmpds);
 	allocated = 1;
 	return Tcl_ExternalToUtfDString(utf8encoding, externalString, -1, &tmpds);

--- a/generic/pgtclCmds.c
+++ b/generic/pgtclCmds.c
@@ -247,8 +247,12 @@ static Tcl_Encoding utf8encoding = NULL;
 /*
  * Initialize utf8encoding
  */
-void pgtclInitEncoding(Tcl_Interp *interp) {
+int pgtclInitEncoding(Tcl_Interp *interp) {
 	utf8encoding = Tcl_GetEncoding(interp, "utf-8");
+	if (utf8encoding != NULL)
+		return TCL_OK;
+	Tcl_SetResult(interp, "Could not initialize encoding utf-8", TCL_STATIC);
+	return TCL_ERROR;
 }
 
 // The following two functions "waste" a DStrings storage by not freeing it until it's needed again

--- a/generic/pgtclCmds.c
+++ b/generic/pgtclCmds.c
@@ -1508,8 +1508,9 @@ Pg_result(ClientData cData, Tcl_Interp *interp, int objc, Tcl_Obj *CONST objv[])
 					char	   *value;
 
 					value = utfString(PGgetvalue(result, resultid->nullValueString, tupno, i));
+
 					if (Tcl_ListObjAppendElement(interp, resultObj, 
-							   Tcl_NewStringObj(utfString(value), -1)) == TCL_ERROR)
+							   Tcl_NewStringObj(value, -1)) == TCL_ERROR)
 						return TCL_ERROR;
 				}
 				Tcl_SetObjResult(interp, resultObj);

--- a/generic/pgtclCmds.h
+++ b/generic/pgtclCmds.h
@@ -17,7 +17,7 @@
 #include <tcl.h>
 #include "libpq-fe.h"
 
-extern void pgtclInitEncoding(Tcl_Interp *interp);
+extern int pgtclInitEncoding(Tcl_Interp *interp);
 
 /* MOVED structure definitions for connection IDs to pctclId.h */
 

--- a/generic/pgtclCmds.h
+++ b/generic/pgtclCmds.h
@@ -17,6 +17,8 @@
 #include <tcl.h>
 #include "libpq-fe.h"
 
+extern void pgtclInitEncoding(Tcl_Interp *interp);
+
 /* MOVED structure definitions for connection IDs to pctclId.h */
 
 /* **************************/

--- a/generic/tokenize.h
+++ b/generic/tokenize.h
@@ -14,7 +14,7 @@ TK_CAST, TK_HASH
 };
 
 int Pg_sqlite3GetToken(const char *z, enum sqltoken *tokenType);
-int handle_substitutions(Tcl_Interp *interp, const char *sql, char **newSqlPtr, const char ***replacementArrayPtr, int *replacementArrayLengthPtr, int hardError);
+int handle_substitutions(Tcl_Interp *interp, const char *sql, char **newSqlPtr, const char ***replacementArrayPtr, int *replacementArrayLengthPtr, const char **bufferPtr);
 
 #define sqlite3Isdigit(x) isdigit(x)
 #define sqlite3Isspace(x) isspace(x)

--- a/tests/pgtcl.test
+++ b/tests/pgtcl.test
@@ -1259,4 +1259,56 @@ test pgtcl-10.3 {copy out} -body {
     set result
 } -result {{name batfink} {studio {Hal Seeger Studios}} {type superhero} {wings steel}}
 
+#
+#
+#
+test pgtcl-11.0 {using pg_exec with 4-byte unicode} -body {
+
+    unset -nocomplain res
+
+    set conn [pg::connect -connlist [array get ::conninfo]]
+
+    set glyph "𝔄"
+
+    set res [$conn exec {SELECT relname
+                           FROM Pg_class
+                          WHERE relname LIKE '$glyph'}]
+
+    set results [pg::result $res -list]
+
+    pg_result $res -clear
+
+    pg_disconnect $conn
+
+    lsort $results
+
+} -result [list]
+
+#
+#
+#
+test pgtcl-11.1 {using pg_exec with 4-byte unicode variables} -body {
+
+    unset -nocomplain res
+
+    set conn [pg::connect -connlist [array get ::conninfo]]
+
+    set glyph "𝔄"
+
+    set res [$conn exec -variables {SELECT relname
+                           FROM Pg_class
+                          WHERE relname LIKE :glyph}]
+
+    set results [pg::result $res -list]
+
+    pg_result $res -clear
+
+    pg_disconnect $conn
+
+    lsort $results
+
+} -result [list]
+
+
+
 puts "tests complete"

--- a/tests/pgtcl.test
+++ b/tests/pgtcl.test
@@ -1101,7 +1101,7 @@ test pgtcl-9.4 {dbinfo backend pid} -body {
     lappend res [string equal $val $val2]
     ::pg::disconnect $conn
 
-    lappend res [regexp {^[0-9]{2,6}$} $val]
+    lappend res [regexp {^[0-9]{2,7}$} $val]
 
 } -result [list 1 1]
 


### PR DESCRIPTION
Tcl UTF strings are not actually utf-8, make sure we convert between utf-8 and Tcl UTF-16-ish utf-8-ish strings where needed.