### PR TITLE
Fix memory leak in build_param_array

### DIFF
--- a/.github/workflows/mac-ci.yml
+++ b/.github/workflows/mac-ci.yml
@@ -16,12 +16,12 @@ jobs:
     - name: Install dependencies
       run: |
         brew update
-        brew install tcl-tk autoconf libpq
+        brew install tcl-tk@8 autoconf libpq
     - name: configure
       run: |       
         autoreconf -vi
         export PG_CONFIG=/opt/homebrew/opt/libpq/bin/pg_config
-        ./configure --with-tcl=/opt/homebrew/opt/tcl-tk/lib/ --prefix=/usr/local        
+        ./configure --with-tcl=/opt/homebrew/opt/tcl-tk@8/lib/ --prefix=/usr/local        
     - name: make
       run: make
     - name: install

--- a/configure.in
+++ b/configure.in
@@ -19,7 +19,7 @@ dnl	to configure the system for the local environment.
 # so you can encode the package version directly into the source files.
 #-----------------------------------------------------------------------
 
-AC_INIT([pgtcl], [3.1.0])
+AC_INIT([pgtcl], [3.1.1])
 
 #-----
 # Version with patch stripped

--- a/generic/pgtclCmds.c
+++ b/generic/pgtclCmds.c
@@ -629,6 +629,7 @@ int build_param_array(Tcl_Interp *interp, int nParams, Tcl_Obj *CONST objv[], co
 	}
 
 	*paramValuesPtr = paramValues;
+	ckfree(paramLengths);
 
 	return TCL_OK;
 }

--- a/generic/pgtclCmds.c
+++ b/generic/pgtclCmds.c
@@ -2928,6 +2928,7 @@ static int expand_parameters(Tcl_Interp *interp, const char *queryString, int nP
 	// Normal return, push parameters and return OK.
 	*paramValuesPtr = paramValues;
 	*newQueryStringPtr = newQueryString;
+	ckfree(paramLengths);
 	return TCL_OK;
 
 error_return:


### PR DESCRIPTION
Previously, `paramLengths` was not being freed during normal operation, only when we returned early due to an error.

I also bumped the version to v3.1.1 and updated the Mac CI build to use `tcl-tk@8` because Homebrew was pulling in Tcl 9.