### PR TITLE
Build fix for Tcl 9.0 (while remaining compatible with Tcl 8.4-8.6)

### DIFF
--- a/generic/pgtclCmds.c
+++ b/generic/pgtclCmds.c
@@ -20,6 +20,7 @@
 
 #include "pgtclCmds.h"
 #include "pgtclId.h"
+#include "pgtclCompat.h"
 #include "libpq/libpq-fs.h"		/* large-object interface */
 #include "tokenize.h"
 
@@ -30,14 +31,14 @@ static int execute_put_values(Tcl_Interp *interp, const char *array_varname,
 				   PGresult *result, char *nullString, int tupno);
 
 static int count_parameters(Tcl_Interp *interp, const char *queryString,
-				    int *nParamsPtr);
+				    Tcl_Size *nParamsPtr);
 
 static int expand_parameters(Tcl_Interp *interp, const char *queryString,
 				    int nParams, char *paramArrayName,
 				    char **newQueryStringPtr, const char ***paramValuesPtr,
 				    const char **bufferPtr);
 
-static int build_param_array(Tcl_Interp *interp, int nParams, Tcl_Obj *CONST objv[], const char ***paramValuesPtr, const char **bufferPtr);
+static int build_param_array(Tcl_Interp *interp, int nParams, Tcl_Obj *const objv[], const char ***paramValuesPtr, const char **bufferPtr);
 
 static void report_connection_error(Tcl_Interp *interp, PGconn *conn);
 
@@ -188,7 +189,7 @@ PGgetvalue ( PGresult *result, char *nullString, int tupno, int fieldNumber )
 
 int
 Pg_conndefaults(ClientData cData, Tcl_Interp *interp, int objc,
-				Tcl_Obj *CONST objv[])
+				Tcl_Obj *const objv[])
 {
 	PQconninfoOption *options = PQconndefaults();
 	PQconninfoOption *option;
@@ -265,7 +266,7 @@ Pg_conndefaults(ClientData cData, Tcl_Interp *interp, int objc,
 
 int
 Pg_connect(ClientData cData, Tcl_Interp *interp, int objc,
-		   Tcl_Obj *CONST objv[])
+		   Tcl_Obj *const objv[])
 {
     PGconn	    *conn;
     char	    *connhandle = NULL;
@@ -362,7 +363,8 @@ Pg_connect(ClientData cData, Tcl_Interp *interp, int objc,
             case OPT_CONNLIST:
             {
                 Tcl_Obj    **elemPtrs;
-                int        count, lelem;
+                Tcl_Size   count;
+                int        lelem;
 
                 Tcl_ListObjGetElements(interp, objv[i + 1], &count, &elemPtrs);
 
@@ -491,7 +493,7 @@ Pg_connect(ClientData cData, Tcl_Interp *interp, int objc,
  **********************************/
 
 int
-Pg_disconnect(ClientData cData, Tcl_Interp *interp, int objc, Tcl_Obj *CONST objv[])
+Pg_disconnect(ClientData cData, Tcl_Interp *interp, int objc, Tcl_Obj *const objv[])
 {
     Pg_ConnectionId *connid;
     Tcl_Channel conn_chan;
@@ -540,7 +542,7 @@ Pg_disconnect(ClientData cData, Tcl_Interp *interp, int objc, Tcl_Obj *CONST obj
 ** allocates and returns buffer containing new strings in bufferPtr
 ** for later disposal.
 */
-int array_to_utf8(Tcl_Interp *interp, const char **paramValues, int *paramLengths, int nParams, const char **bufferPtr)
+int array_to_utf8(Tcl_Interp *interp, const char **paramValues, Tcl_Size *paramLengths, int nParams, const char **bufferPtr)
 {
 	int param;
 	int charsWritten;
@@ -571,7 +573,7 @@ int array_to_utf8(Tcl_Interp *interp, const char **paramValues, int *paramLength
 		tresult = Tcl_NewStringObj(errmsg, -1);
 		Tcl_AppendStringsToObj(tresult, paramValues[param], NULL);
 		if(errcode == TCL_CONVERT_NOSPACE) { // CAN'T HAPPEN, check anyway
-		    sprintf(errmsg, " (%d bytes needed, %d bytes available)", paramLengths[param], remaining);
+		    sprintf(errmsg, " (%d bytes needed, %d bytes available)", (int) paramLengths[param], remaining);
 		    Tcl_AppendStringsToObj(tresult, errmsg, NULL);
 		}
 		Tcl_SetObjResult(interp, tresult);
@@ -596,20 +598,20 @@ int array_to_utf8(Tcl_Interp *interp, const char **paramValues, int *paramLength
  * and PQexecParams will work just like PQexec (no $-substitutions).
  * The magic string NULL is replaced by a null value! // TODO - make this use null value string
  */
-int build_param_array(Tcl_Interp *interp, int nParams, Tcl_Obj *CONST objv[], const char ***paramValuesPtr, const char **bufferPtr)
+int build_param_array(Tcl_Interp *interp, int nParams, Tcl_Obj *const objv[], const char ***paramValuesPtr, const char **bufferPtr)
 {
 	const char **paramValues  = NULL;
-	int         *paramLengths = NULL;
+	Tcl_Size    *paramLengths = NULL;
 	int          param;
 
 	if(nParams == 0)
 	    return TCL_OK;
 
 	paramValues = (const char **)ckalloc (nParams * sizeof (char *));
-	paramLengths = (int *)ckalloc(nParams * sizeof(int));
+	paramLengths = (Tcl_Size *)ckalloc(nParams * sizeof(Tcl_Size));
 
 	for (param = 0; param < nParams; param++) {
-	    int newLength = 0;
+	    Tcl_Size newLength = 0;
 	    paramValues[param] = Tcl_GetStringFromObj(objv[param], &newLength);
 	    if (strcmp(paramValues[param], "NULL") == 0)
             {
@@ -646,7 +648,7 @@ int build_param_array(Tcl_Interp *interp, int nParams, Tcl_Obj *CONST objv[], co
  **********************************/
 
 int
-Pg_exec(ClientData cData, Tcl_Interp *interp, int objc, Tcl_Obj *CONST objv[])
+Pg_exec(ClientData cData, Tcl_Interp *interp, int objc, Tcl_Obj *const objv[])
 {
 	Pg_ConnectionId *connid;
 	PGconn	        *conn;
@@ -657,7 +659,7 @@ Pg_exec(ClientData cData, Tcl_Interp *interp, int objc, Tcl_Obj *CONST objv[])
 	const char     **paramValues = NULL;
 	char		*paramArrayName = NULL;
 	const char      *paramsBuffer = NULL;
-	int              nParams;
+	Tcl_Size         nParams;
 	int              index;
 	int              useVariables = 0;
 
@@ -859,7 +861,7 @@ static void report_connection_error(Tcl_Interp *interp, PGconn *conn)
  **********************************/
 
 int
-Pg_exec_prepared(ClientData cData, Tcl_Interp *interp, int objc, Tcl_Obj *CONST objv[])
+Pg_exec_prepared(ClientData cData, Tcl_Interp *interp, int objc, Tcl_Obj *const objv[])
 {
 	Pg_ConnectionId *connid;
 	PGconn	   *conn;
@@ -912,7 +914,7 @@ Pg_exec_prepared(ClientData cData, Tcl_Interp *interp, int objc, Tcl_Obj *CONST 
 
 	if(statementNameString) {
 		result = PQexecPrepared(conn, statementNameString, nParams, paramValues, NULL, NULL, 0);
-		ckfree(statementNameString);
+		ckfree((void *)statementNameString);
 		statementNameString = NULL;
 	}
 
@@ -1097,7 +1099,7 @@ Pg_result_foreach(Tcl_Interp *interp, PGresult *result, Tcl_Obj *arrayNameObj, T
 
  **********************************/
 int
-Pg_result(ClientData cData, Tcl_Interp *interp, int objc, Tcl_Obj *CONST objv[])
+Pg_result(ClientData cData, Tcl_Interp *interp, int objc, Tcl_Obj *const objv[])
 {
 	PGresult   *result;
 	int			i;
@@ -1140,7 +1142,7 @@ Pg_result(ClientData cData, Tcl_Interp *interp, int objc, Tcl_Obj *CONST objv[])
 		"context", "file", "line", "function", (char *)NULL
 	};
 
-	static CONST char pgDiagCodes[] = {
+	static const char pgDiagCodes[] = {
 		PG_DIAG_SEVERITY,
 		PG_DIAG_SQLSTATE, 
 		PG_DIAG_MESSAGE_PRIMARY,
@@ -1406,11 +1408,11 @@ Pg_result(ClientData cData, Tcl_Interp *interp, int objc, Tcl_Obj *CONST objv[])
 						    ) == NULL)
 						{
 							Tcl_DecrRefCount(fieldNameObj);
-							ckfree(field0);
+							ckfree((void *)field0);
 							return TCL_ERROR;
 						}
 					}
-					ckfree(field0);
+					ckfree((void *)field0);
 				}
 				return TCL_OK;
 			}
@@ -1741,7 +1743,7 @@ Pg_result(ClientData cData, Tcl_Interp *interp, int objc, Tcl_Obj *CONST objv[])
 		case OPT_NULL_VALUE_STRING:
 			{
 				char       *nullValueString;
-				int         length;
+				Tcl_Size    length;
 
 				if ((objc < 3) || (objc > 4))
 				{
@@ -1822,7 +1824,7 @@ Pg_result_errReturn:
  **********************************/
 
 int
-Pg_execute(ClientData cData, Tcl_Interp *interp, int objc, Tcl_Obj *CONST objv[])
+Pg_execute(ClientData cData, Tcl_Interp *interp, int objc, Tcl_Obj *const objv[])
 {
 	Pg_ConnectionId *connid;
 	PGconn	   *conn;
@@ -2136,7 +2138,7 @@ execute_put_values(Tcl_Interp *interp, const char *array_varname,
 **********************/
 
 int
-Pg_lo_open(ClientData cData, Tcl_Interp *interp, int objc, Tcl_Obj *CONST objv[])
+Pg_lo_open(ClientData cData, Tcl_Interp *interp, int objc, Tcl_Obj *const objv[])
 {
 	PGconn	   *conn;
 	int			lobjId;
@@ -2144,7 +2146,7 @@ Pg_lo_open(ClientData cData, Tcl_Interp *interp, int objc, Tcl_Obj *CONST objv[]
 	int			fd;
 	char	   *connString;
 	char	   *modeString;
-	int			modeStringLen;
+	Tcl_Size		modeStringLen;
 	Pg_ConnectionId *connid;
 
 	if (objc != 4)
@@ -2226,7 +2228,7 @@ Pg_lo_open(ClientData cData, Tcl_Interp *interp, int objc, Tcl_Obj *CONST objv[]
 
 **********************/
 int
-Pg_lo_close(ClientData cData, Tcl_Interp *interp, int objc, Tcl_Obj *CONST objv[])
+Pg_lo_close(ClientData cData, Tcl_Interp *interp, int objc, Tcl_Obj *const objv[])
 {
 	PGconn	   *conn;
 	int			fd;
@@ -2272,7 +2274,7 @@ Pg_lo_close(ClientData cData, Tcl_Interp *interp, int objc, Tcl_Obj *CONST objv[
 **********************/
 int
 Pg_lo_read(ClientData cData, Tcl_Interp *interp, int objc,
-		   Tcl_Obj *CONST objv[])
+		   Tcl_Obj *const objv[])
 {
 	PGconn	   *conn;
 	int			fd;
@@ -2323,7 +2325,7 @@ Pg_lo_read(ClientData cData, Tcl_Interp *interp, int objc,
 	        bufObj = Tcl_NewByteArrayObj((unsigned char*)buf, nbytes);
 
 	    if (Tcl_ObjSetVar2(interp, bufVar, NULL, bufObj,
-					   TCL_LEAVE_ERR_MSG | TCL_PARSE_PART1) == NULL)
+					   TCL_LEAVE_ERR_MSG) == NULL)
 		rc = TCL_ERROR;
         }
    
@@ -2344,12 +2346,12 @@ Pg_lo_write
 ***********************************/
 int
 Pg_lo_write(ClientData cData, Tcl_Interp *interp, int objc,
-			Tcl_Obj *CONST objv[])
+			Tcl_Obj *const objv[])
 {
 	PGconn	   *conn;
 	char	   *buf;
 	int			fd;
-	int			nbytes = 0;
+	Tcl_Size		nbytes = 0;
 	int			len;
 	Pg_ConnectionId *connid;
 
@@ -2405,7 +2407,7 @@ whence can be either
 ***********************************/
 int
 Pg_lo_lseek(ClientData cData, Tcl_Interp *interp, int objc,
-			Tcl_Obj *CONST objv[])
+			Tcl_Obj *const objv[])
 {
 	PGconn	   *conn;
 	int			fd;
@@ -2475,7 +2477,7 @@ for now, we don't support any additional storage managers.
 ***********************************/
 int
 Pg_lo_creat(ClientData cData, Tcl_Interp *interp, int objc,
-			Tcl_Obj *CONST objv[])
+			Tcl_Obj *const objv[])
 {
 	PGconn	   *conn;
 	char	   *modeStr;
@@ -2548,7 +2550,7 @@ Pg_lo_tell
 ***********************************/
 int
 Pg_lo_tell(ClientData cData, Tcl_Interp *interp, int objc,
-		   Tcl_Obj *CONST objv[])
+		   Tcl_Obj *const objv[])
 {
 	PGconn	   *conn;
 	int			fd;
@@ -2593,7 +2595,7 @@ Pg_lo_truncate
 ***********************************/
 int
 Pg_lo_truncate(ClientData cData, Tcl_Interp *interp, int objc,
-		   Tcl_Obj *CONST objv[])
+		   Tcl_Obj *const objv[])
 {
 	PGconn	   *conn;
 	int			fd;
@@ -2644,7 +2646,7 @@ Pg_lo_unlink
 ***********************************/
 int
 Pg_lo_unlink(ClientData cData, Tcl_Interp *interp, int objc,
-			 Tcl_Obj *CONST objv[])
+			 Tcl_Obj *const objv[])
 {
 	PGconn	   *conn;
 	int			lobjId;
@@ -2698,7 +2700,7 @@ Pg_lo_import
 
 int
 Pg_lo_import(ClientData cData, Tcl_Interp *interp, int objc,
-			 Tcl_Obj *CONST objv[])
+			 Tcl_Obj *const objv[])
 {
 	PGconn	   *conn;
 	const char	   *filename;
@@ -2749,7 +2751,7 @@ Pg_lo_export
 
 int
 Pg_lo_export(ClientData cData, Tcl_Interp *interp, int objc,
-			 Tcl_Obj *CONST objv[])
+			 Tcl_Obj *const objv[])
 {
 	PGconn	   *conn;
 	const char	   *filename;
@@ -2800,7 +2802,7 @@ Pg_lo_export(ClientData cData, Tcl_Interp *interp, int objc,
 
  If successful, sets nParams to the number of expected parameters in queryString
  */
-static int count_parameters(Tcl_Interp *interp, const char *queryString, int *nParamsPtr)
+static int count_parameters(Tcl_Interp *interp, const char *queryString, Tcl_Size *nParamsPtr)
 {
 
     int nQuotes = 0;
@@ -2839,7 +2841,7 @@ static int expand_parameters(Tcl_Interp *interp, const char *queryString, int nP
 	// Allocating space for parameter IDs up to 100,000 (5 characters)
 	char        *newQueryString = (char *)ckalloc(strlen(queryString) + 5 * nParams);
 	const char **paramValues    = (const char **)ckalloc(nParams * sizeof (*paramValues));
-	int         *paramLengths   = (int *)ckalloc(nParams * sizeof (int));
+	Tcl_Size    *paramLengths   = (Tcl_Size *)ckalloc(nParams * sizeof (Tcl_Size));
 	const char   *input         = queryString;
 	char         *output        = newQueryString;
 	int           paramIndex    = 0;
@@ -2982,7 +2984,7 @@ error_return:
  **********************************/
 
 int
-Pg_select(ClientData cData, Tcl_Interp *interp, int objc, Tcl_Obj *CONST objv[])
+Pg_select(ClientData cData, Tcl_Interp *interp, int objc, Tcl_Obj *const objv[])
 {
 	Pg_ConnectionId *connid;
 	PGconn	    *conn = NULL;
@@ -2997,7 +2999,7 @@ Pg_select(ClientData cData, Tcl_Interp *interp, int objc, Tcl_Obj *CONST objv[])
 	int          rowByRow = 0;
 	int          firstPass = 1;
 	int          index = 1;
-	int          nParams = 0;
+	Tcl_Size     nParams = 0;
 	char        *connString     = NULL;
 	char        *pgString       = NULL;
 	const char  *queryString    = NULL;
@@ -3012,7 +3014,6 @@ Pg_select(ClientData cData, Tcl_Interp *interp, int objc, Tcl_Obj *CONST objv[])
 	char        *newQueryString = NULL;
 	Tcl_Obj     *paramListObj   = NULL;
 	int          useVariables = 0;
-	int          tuplesProcessed = 0;
 	Tcl_Obj     *tuplesVarObj  = NULL;
 
 	enum         positionalArgs {SELECT_ARG_CONN, SELECT_ARG_QUERY, SELECT_ARG_VAR, SELECT_ARG_PROC, SELECT_ARGS};
@@ -3347,8 +3348,6 @@ Pg_select(ClientData cData, Tcl_Interp *interp, int objc, Tcl_Obj *CONST objv[])
 				}
 			}
 
-			tuplesProcessed++;
-
 			// Run the code body.
 			r = Tcl_EvalObjEx(interp, procStringObj, 0);
 			if ((r != TCL_OK) && (r != TCL_CONTINUE))
@@ -3456,7 +3455,7 @@ Pg_listen
    vwait or update can be used to enter the Tcl event loop.
 ***********************************/
 int
-Pg_listen(ClientData cData, Tcl_Interp *interp, int objc, Tcl_Obj *CONST objv[])
+Pg_listen(ClientData cData, Tcl_Interp *interp, int objc, Tcl_Obj *const objv[])
 {
 	const char	   *origrelname;
 	char	   *caserelname;
@@ -3468,8 +3467,8 @@ Pg_listen(ClientData cData, Tcl_Interp *interp, int objc, Tcl_Obj *CONST objv[])
 	PGresult   *result;
 	int			new;
 	char	   *connString;
-	int			callbackStrlen = 0;
-	int         origrelnameStrlen;
+	Tcl_Size		callbackStrlen = 0;
+	Tcl_Size    origrelnameStrlen;
         Tcl_Obj     *tresult;
 
 	if (objc < 3 || objc > 4)
@@ -3650,7 +3649,7 @@ Pg_listen(ClientData cData, Tcl_Interp *interp, int objc, Tcl_Obj *CONST objv[])
  **********************************/
 int
 Pg_sendquery(ClientData cData, Tcl_Interp *interp, int objc,
-			 Tcl_Obj *CONST objv[])
+			 Tcl_Obj *const objv[])
 {
 	Pg_ConnectionId *connid;
 	PGconn	        *conn;
@@ -3661,7 +3660,7 @@ Pg_sendquery(ClientData cData, Tcl_Interp *interp, int objc,
 	const char     **paramValues = NULL;
 	char		*paramArrayName = NULL;
 	const char      *paramsBuffer = NULL;
-	int              nParams;
+	Tcl_Size         nParams;
 	int              index;
 	int              useVariables = 0;
 
@@ -3815,7 +3814,7 @@ Pg_sendquery(ClientData cData, Tcl_Interp *interp, int objc,
  **********************************/
 
 int
-Pg_sendquery_prepared(ClientData cData, Tcl_Interp *interp, int objc, Tcl_Obj *CONST objv[])
+Pg_sendquery_prepared(ClientData cData, Tcl_Interp *interp, int objc, Tcl_Obj *const objv[])
 {
 	Pg_ConnectionId *connid;
 	PGconn	   *conn;
@@ -3912,7 +3911,7 @@ Pg_sendquery_prepared(ClientData cData, Tcl_Interp *interp, int objc, Tcl_Obj *C
 
 int
 Pg_set_single_row_mode(ClientData cData, Tcl_Interp *interp, int objc,
-			Tcl_Obj *CONST objv[])
+			Tcl_Obj *const objv[])
 {
 #ifndef HAVE_PQSETSINGLEROWMODE
                 Tcl_SetObjResult(interp, 
@@ -3958,7 +3957,7 @@ Pg_set_single_row_mode(ClientData cData, Tcl_Interp *interp, int objc,
 
 int
 Pg_getresult(ClientData cData, Tcl_Interp *interp, int objc,
-			 Tcl_Obj *CONST objv[])
+			 Tcl_Obj *const objv[])
 {
 	Pg_ConnectionId *connid;
 	PGconn	   *conn;
@@ -4034,7 +4033,7 @@ Pg_getresult(ClientData cData, Tcl_Interp *interp, int objc,
 
 int
 Pg_getdata(ClientData cData, Tcl_Interp *interp, int objc,
-			 Tcl_Obj *CONST objv[])
+			 Tcl_Obj *const objv[])
 {
     Pg_ConnectionId *connid;
     PGconn	    *conn;
@@ -4161,7 +4160,7 @@ Pg_getdata(ClientData cData, Tcl_Interp *interp, int objc,
 
 int
 Pg_isbusy(ClientData cData, Tcl_Interp *interp, int objc,
-		  Tcl_Obj *CONST objv[])
+		  Tcl_Obj *const objv[])
 {
 	Pg_ConnectionId *connid;
 	PGconn	   *conn;
@@ -4206,7 +4205,7 @@ Pg_isbusy(ClientData cData, Tcl_Interp *interp, int objc,
 
 int
 Pg_blocking(ClientData cData, Tcl_Interp *interp, int objc,
-			Tcl_Obj *CONST objv[])
+			Tcl_Obj *const objv[])
 {
 	Pg_ConnectionId *connid;
 	PGconn	   *conn;
@@ -4253,13 +4252,13 @@ Pg_blocking(ClientData cData, Tcl_Interp *interp, int objc,
 
 int
 Pg_null_value_string(ClientData cData, Tcl_Interp *interp, int objc,
-			         Tcl_Obj *CONST objv[])
+			         Tcl_Obj *const objv[])
 {
 	Pg_ConnectionId *connid;
 	PGconn	   *conn;
 	char	   *connString;
 	char       *nullValueString;
-	int			length;
+	Tcl_Size		length;
 
 	if ((objc < 2) || (objc > 3))
 	{
@@ -4310,7 +4309,7 @@ Pg_null_value_string(ClientData cData, Tcl_Interp *interp, int objc,
 
 int
 Pg_cancelrequest(ClientData cData, Tcl_Interp *interp, int objc,
-				 Tcl_Obj *CONST objv[])
+				 Tcl_Obj *const objv[])
 {
 	Pg_ConnectionId *connid;
 	PGconn	   *conn;
@@ -4372,7 +4371,7 @@ Pg_on_connection_loss
 ***********************************/
 int
 Pg_on_connection_loss(ClientData cData, Tcl_Interp *interp, int objc,
-				 Tcl_Obj *CONST objv[])
+				 Tcl_Obj *const objv[])
 {
 	char	   *callback = NULL;
 	Pg_TclNotifies *notifies;
@@ -4396,7 +4395,7 @@ Pg_on_connection_loss(ClientData cData, Tcl_Interp *interp, int objc,
 
 	if (objc > 2)
 	{
-		int         callbackStrLen;
+		Tcl_Size    callbackStrLen;
 		char	   *callbackStr;
 
 		/* there is probably a better way to do this, like incrementing
@@ -4474,11 +4473,11 @@ Pg_on_connection_loss(ClientData cData, Tcl_Interp *interp, int objc,
  */
 int
 Pg_quote (ClientData cData, Tcl_Interp *interp, int objc,
-		  Tcl_Obj *CONST objv[])
+		  Tcl_Obj *const objv[])
 {
 	char	   *fromString = NULL;
 	char	   *toString;
-	int         fromStringLen;
+	Tcl_Size    fromStringLen;
 	int         stringSize;
 	Pg_ConnectionId *connid = NULL;
 	PGconn	   *conn = NULL;
@@ -4662,11 +4661,11 @@ Pg_quote (ClientData cData, Tcl_Interp *interp, int objc,
  */
 int
 Pg_escapeBytea(ClientData cData, Tcl_Interp *interp, int objc,
-                                 Tcl_Obj *CONST objv[])
+                                 Tcl_Obj *const objv[])
 {
         unsigned char    	*from;
         unsigned char           *to;
-        int                      fromLen;
+        Tcl_Size                 fromLen;
         size_t                   toLen;
 	PGconn	                *conn = NULL;
 	char                    *connString;
@@ -4740,11 +4739,11 @@ Pg_escapeBytea(ClientData cData, Tcl_Interp *interp, int objc,
  */
 int
 Pg_unescapeBytea(ClientData cData, Tcl_Interp *interp, int objc,
-                                 Tcl_Obj *CONST objv[])
+                                 Tcl_Obj *const objv[])
 {
     const unsigned char  *from;
     unsigned char        *to;
-    int         fromLen;
+    Tcl_Size    fromLen;
     size_t      toLen;
 
     if (objc != 2)
@@ -4811,7 +4810,7 @@ Pg_unescapeBytea(ClientData cData, Tcl_Interp *interp, int objc,
  */
 int
 Pg_dbinfo(ClientData cData, Tcl_Interp *interp, int objc,
-				 Tcl_Obj *CONST objv[])
+				 Tcl_Obj *const objv[])
 {
     Pg_ConnectionId *connid = NULL;
     char	    *connString = NULL;
@@ -4819,7 +4818,8 @@ Pg_dbinfo(ClientData cData, Tcl_Interp *interp, int objc,
     Tcl_Obj         *listObj;
     Tcl_Obj         *tresult;
     Tcl_Obj         **elemPtrs;
-    int             i, count, optIndex;
+    int             i, optIndex;
+    Tcl_Size        count;
     Tcl_Channel     conn_chan;
     const char      *paramname;
 
@@ -5170,7 +5170,7 @@ Pg_dbinfo(ClientData cData, Tcl_Interp *interp, int objc,
  */
 int
 Pg_sql(ClientData cData, Tcl_Interp *interp, int objc,
-				 Tcl_Obj *CONST objv[])
+				 Tcl_Obj *const objv[])
 {
 
     PGconn          *conn;
@@ -5185,7 +5185,8 @@ Pg_sql(ClientData cData, Tcl_Interp *interp, int objc,
     Tcl_Obj         **elemPtrs;
     Tcl_Obj         **elembinPtrs;
     int             i=3;
-    int             count=0, countbin=0, optIndex;
+    Tcl_Size        count=0, countbin=0;
+    int             optIndex;
     int             params=0,binparams=0,binresults=0,callback=0,async=0,prepared=0;
     unsigned char   flags = 0;
 
@@ -5398,7 +5399,7 @@ Pg_sql(ClientData cData, Tcl_Interp *interp, int objc,
         }
     } /* end if callback */
 
-    ckfree(execString);
+    ckfree((void *)execString);
     execString = NULL;
 
     PgNotifyTransferEvents(connid);

--- a/generic/pgtclCmds.h
+++ b/generic/pgtclCmds.h
@@ -15,6 +15,7 @@
 #define PGTCLCMDS_H
 
 #include <tcl.h>
+#include "pgtclCompat.h"
 #include "libpq-fe.h"
 
 extern int pgtclInitEncoding(Tcl_Interp *interp);
@@ -25,108 +26,108 @@ extern int pgtclInitEncoding(Tcl_Interp *interp);
 /* registered Tcl functions */
 /* **************************/
 extern int Pg_conndefaults(
-  ClientData cData, Tcl_Interp *interp, int objc, Tcl_Obj *CONST objv[]);
+  ClientData cData, Tcl_Interp *interp, int objc, Tcl_Obj *const objv[]);
 
 extern int Pg_connect(
-  ClientData cData, Tcl_Interp *interp, int objc, Tcl_Obj *CONST objv[]);
+  ClientData cData, Tcl_Interp *interp, int objc, Tcl_Obj *const objv[]);
 
 extern int Pg_disconnect(
-  ClientData cData, Tcl_Interp *interp, int objc, Tcl_Obj *CONST objv[]);
+  ClientData cData, Tcl_Interp *interp, int objc, Tcl_Obj *const objv[]);
 
 extern int Pg_exec(
-  ClientData cData, Tcl_Interp *interp, int objc, Tcl_Obj *CONST objv[]);
+  ClientData cData, Tcl_Interp *interp, int objc, Tcl_Obj *const objv[]);
 
 extern int Pg_exec_prepared(
-  ClientData cData, Tcl_Interp *interp, int objc, Tcl_Obj *CONST objv[]);
+  ClientData cData, Tcl_Interp *interp, int objc, Tcl_Obj *const objv[]);
 
 extern int Pg_execute(
-  ClientData cData, Tcl_Interp *interp, int objc, Tcl_Obj *CONST objv[]);
+  ClientData cData, Tcl_Interp *interp, int objc, Tcl_Obj *const objv[]);
 
 extern int Pg_select(
-  ClientData cData, Tcl_Interp *interp, int objc, Tcl_Obj *CONST objv[]);
+  ClientData cData, Tcl_Interp *interp, int objc, Tcl_Obj *const objv[]);
 
 extern int Pg_result(
-  ClientData cData, Tcl_Interp *interp, int objc, Tcl_Obj *CONST objv[]);
+  ClientData cData, Tcl_Interp *interp, int objc, Tcl_Obj *const objv[]);
 
 extern int Pg_lo_open(
-  ClientData cData, Tcl_Interp *interp, int objc, Tcl_Obj *CONST objv[]);
+  ClientData cData, Tcl_Interp *interp, int objc, Tcl_Obj *const objv[]);
 
 extern int Pg_lo_close(
-  ClientData cData, Tcl_Interp *interp, int objc, Tcl_Obj *CONST objv[]);
+  ClientData cData, Tcl_Interp *interp, int objc, Tcl_Obj *const objv[]);
 
 extern int Pg_lo_read(
-  ClientData cData, Tcl_Interp *interp, int objc, Tcl_Obj *CONST objv[]);
+  ClientData cData, Tcl_Interp *interp, int objc, Tcl_Obj *const objv[]);
 
 extern int Pg_lo_write(
-  ClientData cData, Tcl_Interp *interp, int objc, Tcl_Obj *CONST objv[]);
+  ClientData cData, Tcl_Interp *interp, int objc, Tcl_Obj *const objv[]);
 
 extern int Pg_lo_lseek(
-  ClientData cData, Tcl_Interp *interp, int objc, Tcl_Obj *CONST objv[]);
+  ClientData cData, Tcl_Interp *interp, int objc, Tcl_Obj *const objv[]);
 
 extern int Pg_lo_creat(
-  ClientData cData, Tcl_Interp *interp, int objc, Tcl_Obj *CONST objv[]);
+  ClientData cData, Tcl_Interp *interp, int objc, Tcl_Obj *const objv[]);
 
 extern int Pg_lo_tell(
-  ClientData cData, Tcl_Interp *interp, int objc, Tcl_Obj *CONST objv[]);
+  ClientData cData, Tcl_Interp *interp, int objc, Tcl_Obj *const objv[]);
 
 extern int Pg_lo_truncate(
-  ClientData cData, Tcl_Interp *interp, int objc, Tcl_Obj *CONST objv[]);
+  ClientData cData, Tcl_Interp *interp, int objc, Tcl_Obj *const objv[]);
 
 extern int Pg_lo_unlink(
-  ClientData cData, Tcl_Interp *interp, int objc, Tcl_Obj *CONST objv[]);
+  ClientData cData, Tcl_Interp *interp, int objc, Tcl_Obj *const objv[]);
 
 extern int Pg_lo_import(
-  ClientData cData, Tcl_Interp *interp, int objc, Tcl_Obj *CONST objv[]);
+  ClientData cData, Tcl_Interp *interp, int objc, Tcl_Obj *const objv[]);
 
 extern int Pg_lo_export(
-  ClientData cData, Tcl_Interp *interp, int objc, Tcl_Obj *CONST objv[]);
+  ClientData cData, Tcl_Interp *interp, int objc, Tcl_Obj *const objv[]);
 
 extern int Pg_listen(
-  ClientData cData, Tcl_Interp *interp, int objc, Tcl_Obj *CONST objv[]);
+  ClientData cData, Tcl_Interp *interp, int objc, Tcl_Obj *const objv[]);
 
 extern int Pg_sendquery(
-  ClientData cData, Tcl_Interp *interp, int objc, Tcl_Obj *CONST objv[]);
+  ClientData cData, Tcl_Interp *interp, int objc, Tcl_Obj *const objv[]);
 
 extern int Pg_sendquery_prepared(
-  ClientData cData, Tcl_Interp *interp, int objc, Tcl_Obj *CONST objv[]);
+  ClientData cData, Tcl_Interp *interp, int objc, Tcl_Obj *const objv[]);
 
 extern int Pg_getresult(
-  ClientData cData, Tcl_Interp *interp, int objc, Tcl_Obj *CONST objv[]);
+  ClientData cData, Tcl_Interp *interp, int objc, Tcl_Obj *const objv[]);
 
 extern int Pg_set_single_row_mode(
-  ClientData cData, Tcl_Interp *interp, int objc, Tcl_Obj *CONST objv[]);
+  ClientData cData, Tcl_Interp *interp, int objc, Tcl_Obj *const objv[]);
 
 extern int Pg_isbusy(
-  ClientData cData, Tcl_Interp *interp, int objc, Tcl_Obj *CONST objv[]);
+  ClientData cData, Tcl_Interp *interp, int objc, Tcl_Obj *const objv[]);
 
 extern int Pg_blocking(
-  ClientData cData, Tcl_Interp *interp, int objc, Tcl_Obj *CONST objv[]);
+  ClientData cData, Tcl_Interp *interp, int objc, Tcl_Obj *const objv[]);
 
 extern int Pg_null_value_string(
-  ClientData cData, Tcl_Interp *interp, int objc, Tcl_Obj *CONST objv[]);
+  ClientData cData, Tcl_Interp *interp, int objc, Tcl_Obj *const objv[]);
 
 extern int Pg_cancelrequest(
-  ClientData cData, Tcl_Interp *interp, int objc, Tcl_Obj *CONST objv[]);
+  ClientData cData, Tcl_Interp *interp, int objc, Tcl_Obj *const objv[]);
 
 extern int Pg_on_connection_loss(
-  ClientData cData, Tcl_Interp *interp, int objc, Tcl_Obj *CONST objv[]);
+  ClientData cData, Tcl_Interp *interp, int objc, Tcl_Obj *const objv[]);
 
 extern int Pg_quote(
-  ClientData cData, Tcl_Interp *interp, int objc, Tcl_Obj *CONST objv[]);
+  ClientData cData, Tcl_Interp *interp, int objc, Tcl_Obj *const objv[]);
 
 extern int Pg_escapeBytea(
-  ClientData cData, Tcl_Interp *interp, int objc, Tcl_Obj *CONST objv[]);
+  ClientData cData, Tcl_Interp *interp, int objc, Tcl_Obj *const objv[]);
 
 extern int Pg_unescapeBytea(
-  ClientData cData, Tcl_Interp *interp, int objc, Tcl_Obj *CONST objv[]);
+  ClientData cData, Tcl_Interp *interp, int objc, Tcl_Obj *const objv[]);
 
 extern int Pg_dbinfo(
-  ClientData cData, Tcl_Interp *interp, int objc, Tcl_Obj *CONST objv[]);
+  ClientData cData, Tcl_Interp *interp, int objc, Tcl_Obj *const objv[]);
 
 extern int Pg_getdata(
-  ClientData cData, Tcl_Interp *interp, int objc, Tcl_Obj *CONST objv[]);
+  ClientData cData, Tcl_Interp *interp, int objc, Tcl_Obj *const objv[]);
 
 extern int Pg_sql(
-  ClientData cData, Tcl_Interp *interp, int objc, Tcl_Obj *CONST objv[]);
+  ClientData cData, Tcl_Interp *interp, int objc, Tcl_Obj *const objv[]);
 
 #endif   /* PGTCLCMDS_H */

--- a/generic/pgtclCompat.h
+++ b/generic/pgtclCompat.h
@@ -1,0 +1,42 @@
+/*-------------------------------------------------------------------------
+ *
+ * pgtclCompat.h
+ *
+ *	Small compatibility shim so that pgtcl can be built against both
+ *	Tcl 8.x (8.4 through 8.6) and Tcl 9.0.
+ *
+ *	Tcl 9.0 made two changes that affect every file in this package:
+ *
+ *	  1. The ancient "CONST"/"CONST84"/"CONST86" macros (kept around
+ *	     since the Tcl 8.0 days for extensions that still needed to
+ *	     build against Tcl 7.x/8.0) were removed.  Plain "const" has
+ *	     been the correct, portable spelling since Tcl 8.4, so pgtcl's
+ *	     sources have been updated to just use "const" directly -- no
+ *	     fallback is required here.
+ *
+ *	  2. String/list lengths and element counts that used to be passed
+ *	     around as "int" (e.g. the out-parameters of Tcl_GetStringFromObj,
+ *	     Tcl_GetByteArrayFromObj, Tcl_ListObjGetElements, Tcl_ListObjLength)
+ *	     now use the new "Tcl_Size" type, which is wide enough to hold
+ *	     lengths greater than INT_MAX on 64-bit builds.  Tcl 8.x does not
+ *	     define Tcl_Size at all, so provide a fallback typedef for it.
+ *
+ *	See https://www.tcl-lang.org/doc/howto/size_t.html for the upstream
+ *	description of this migration.
+ *
+ *-------------------------------------------------------------------------
+ */
+
+#ifndef PGTCL_COMPAT_H
+#define PGTCL_COMPAT_H
+
+#include <tcl.h>
+
+#ifndef TCL_SIZE_MAX
+#ifndef Tcl_Size
+/* Tcl 8.x without the Tcl_Size backport: all the affected APIs use "int" */
+typedef int Tcl_Size;
+#endif
+#endif
+
+#endif   /* PGTCL_COMPAT_H */

--- a/generic/pgtclId.c
+++ b/generic/pgtclId.c
@@ -208,7 +208,7 @@ PgSetConnectionId(Tcl_Interp *interp, PGconn *conn, char *chandle)
         Tcl_Obj         *nsstr;
 	Pg_ConnectionId *connid;
 	int             i;
-        CONST char      *ns = "";
+        const char      *ns = "";
 
 	connid = (Pg_ConnectionId *) ckalloc(sizeof(Pg_ConnectionId));
 	connid->conn = conn;
@@ -304,7 +304,7 @@ PgSetConnectionId(Tcl_Interp *interp, PGconn *conn, char *chandle)
  *----------------------------------------------------------------------
  */
 int
-PgConnCmd(ClientData cData, Tcl_Interp *interp, int objc, Tcl_Obj *CONST objv[])
+PgConnCmd(ClientData cData, Tcl_Interp *interp, int objc, Tcl_Obj *const objv[])
 {
     int             optIndex;
     int             objvxi;
@@ -681,7 +681,7 @@ PgConnCmd(ClientData cData, Tcl_Interp *interp, int objc, Tcl_Obj *CONST objv[])
  *----------------------------------------------------------------------
  */
 int
-PgResultCmd(ClientData cData, Tcl_Interp *interp, int objc, Tcl_Obj *CONST objv[])
+PgResultCmd(ClientData cData, Tcl_Interp *interp, int objc, Tcl_Obj *const objv[])
 {
     int    objvxi;
     Tcl_Obj    *objvx[25];
@@ -972,7 +972,7 @@ getresid(Tcl_Interp *interp, const char *id, Pg_ConnectionId ** connid_p)
 	int			resid;
 	Pg_ConnectionId *connid;
 
-	if (!(mark = strrchr(id, '.')))
+	if (!(mark = (char *) strrchr(id, '.')))
 	{
 		Tcl_SetResult(interp, "Poorly formated result handle", TCL_STATIC);
 		return -1;
@@ -1066,7 +1066,7 @@ PgGetConnByResultId(Tcl_Interp *interp, const char *resid_c)
 	Tcl_Channel conn_chan;
     Tcl_Obj     *tresult;
 
-	if (!(mark = strrchr(resid_c, '.')))
+	if (!(mark = (char *) strrchr(resid_c, '.')))
 		goto error_out;
 	*mark = '\0';
 	conn_chan = Tcl_GetChannel(interp, resid_c, 0);
@@ -1581,7 +1581,7 @@ PgDelResultHandle(ClientData cData)
 
 int
 Pg_copy_complete(ClientData cData, Tcl_Interp *interp, int objc,
-				 Tcl_Obj *CONST objv[])
+				 Tcl_Obj *const objv[])
 {
 	Pg_ConnectionId *connid;
 	PGconn	   *conn;

--- a/generic/pgtclId.h
+++ b/generic/pgtclId.h
@@ -15,6 +15,8 @@
  *-------------------------------------------------------------------------
  */
 
+#include "pgtclCompat.h"
+
 #define RES_HARD_MAX 128
 #define RES_START 16
 
@@ -120,13 +122,13 @@ extern void PgNotifyTransferEvents(Pg_ConnectionId * connid);
 extern void PgConnLossTransferEvents(Pg_ConnectionId * connid);
 extern void PgNotifyInterpDelete(ClientData clientData, Tcl_Interp *interp);
 
-extern int PgConnCmd(ClientData cData, Tcl_Interp *interp, int objc, Tcl_Obj *CONST objv[]);
+extern int PgConnCmd(ClientData cData, Tcl_Interp *interp, int objc, Tcl_Obj *const objv[]);
 extern void PgDelCmdHandle(ClientData cData);
 extern void PgDelResultHandle(ClientData cData);
 
 extern Tcl_ChannelType Pg_ConnType;
 
 extern int Pg_copy_complete(
-  ClientData cData, Tcl_Interp *interp, int objc, Tcl_Obj *CONST objv[]);
+  ClientData cData, Tcl_Interp *interp, int objc, Tcl_Obj *const objv[]);
 
 extern int PgCheckConnectionState(Pg_ConnectionId *connid);

--- a/generic/pgtclSqlite.c
+++ b/generic/pgtclSqlite.c
@@ -10,6 +10,7 @@
 
 #include "pgtclCmds.h"
 #include "pgtclId.h"
+#include "pgtclCompat.h"
 
 #include <sqlite3.h>
 
@@ -181,10 +182,10 @@ char *Pg_sqlite_typename(enum mappedTypes type)
 // Step through a list and produce an array of the types in the list. Since the list may be a list of types
 // or a list of names and types, we take a start index and stride to describe the list.
 int
-Pg_sqlite_mapTypes(Tcl_Interp *interp, Tcl_Obj *list, int start, int stride, enum mappedTypes **arrayPtr, int *lengthPtr)
+Pg_sqlite_mapTypes(Tcl_Interp *interp, Tcl_Obj *list, int start, int stride, enum mappedTypes **arrayPtr, Tcl_Size *lengthPtr)
 {
 	Tcl_Obj          **objv;
-	int                objc;
+	Tcl_Size           objc;
 	enum mappedTypes  *array;
 	int                i;
 	int                col;
@@ -225,10 +226,10 @@ Pg_sqlite_mapTypes(Tcl_Interp *interp, Tcl_Obj *list, int start, int stride, enu
 // Step through a list and produce an array of the names in the list. Since the list may be a list of types
 // or a list of names and types, we take a stride to describe the list.
 int
-Pg_sqlite_getNames(Tcl_Interp *interp, Tcl_Obj *list, int stride, char ***arrayPtr, int *lengthPtr)
+Pg_sqlite_getNames(Tcl_Interp *interp, Tcl_Obj *list, int stride, char ***arrayPtr, Tcl_Size *lengthPtr)
 {
 	Tcl_Obj **objv;
-	int       objc;
+	Tcl_Size  objc;
 	char    **array;
 	int       i;
 	int       col;
@@ -331,7 +332,7 @@ int
 Pg_sqlite_generateCheck(Tcl_Interp *interp, sqlite3 *sqlite_db, char *tableName, char **columnNames, int nColumns, Tcl_Obj *primaryKey, sqlite3_stmt **statementPtr, int **primaryKeyIndexPtr)
 {
 	Tcl_Obj     **keyv;
-	int           keyc;
+	Tcl_Size      keyc;
 	int          *primaryKeyIndex = NULL;
 	char        **primaryKeyNames = NULL;
 	Tcl_Obj      *sql = NULL;
@@ -567,9 +568,9 @@ Tcl_Obj*
 Pg_sqlite_generate(Tcl_Interp *interp, sqlite3 *sqlite_db, char *sqliteTable, Tcl_Obj *nameList, Tcl_Obj *nameTypeList, Tcl_Obj *primaryKey, char *unknownKey, int newTable, int replacing)
 {
 	Tcl_Obj **objv;
-	int       objc;
+	Tcl_Size  objc;
 	Tcl_Obj **keyv = NULL;
-	int       keyc = 0;
+	Tcl_Size  keyc = 0;
 	Tcl_Obj  *create = NULL;
 	Tcl_Obj  *sql = NULL;
 	Tcl_Obj  *values = NULL;
@@ -727,7 +728,7 @@ Pg_sqlite_probe(Tcl_Interp *interp, Tcl_ObjCmdProc **procPtr)
 		char               cmd_name[256 + 1];
 		char               create_cmd[256 + 18 + 1];
 		char               delete_cmd[256 + 7 + 1];
-		struct Tcl_CmdInfo cmd_info;
+		Tcl_CmdInfo cmd_info;
 
 		if (Tcl_Eval(interp, "package require sqlite3") != TCL_OK) {
 			return TCL_ERROR;
@@ -890,7 +891,7 @@ Pg_sqlite_split_keyval(Tcl_Interp *interp, char *row, char ***columnsPtr, int nC
 
 int Pg_sqlite_getDB(Tcl_Interp *interp, char *cmdName, sqlite3 **sqlite_dbPtr)
 {
-        struct Tcl_CmdInfo  sqlite_commandInfo;
+        Tcl_CmdInfo  sqlite_commandInfo;
 	Tcl_ObjCmdProc     *sqlite3_ObjProc = NULL;
         struct SqliteDb    *sqlite_clientData;
 
@@ -918,7 +919,7 @@ int Pg_sqlite_getDB(Tcl_Interp *interp, char *cmdName, sqlite3 **sqlite_dbPtr)
 
 // Main routine, extract the sqlite handle, parse the ensemble command, and run the subcommand.
 int
-Pg_sqlite(ClientData clientdata, Tcl_Interp *interp, int objc, Tcl_Obj *CONST objv[])
+Pg_sqlite(ClientData clientdata, Tcl_Interp *interp, int objc, Tcl_Obj *const objv[])
 {
         sqlite3            *sqlite_db;
 	int                 cmdIndex;
@@ -984,7 +985,7 @@ Pg_sqlite(ClientData clientdata, Tcl_Interp *interp, int objc, Tcl_Obj *CONST ob
 	const char        *errorMessage = NULL;
 	enum mappedTypes  *columnTypes = NULL;
 	char             **columnNames = NULL;
-	int                nColumns = 0;
+	Tcl_Size           nColumns = 0;
 	int                column;
 	ExecStatusType     status;
 	char              *tabsepFile = NULL;
@@ -1532,7 +1533,7 @@ Pg_sqlite(ClientData clientdata, Tcl_Interp *interp, int objc, Tcl_Obj *CONST ob
 
 			while(row) {
 				if(cmdIndex == CMD_READ_KEYVAL) {
-					int len;
+					Tcl_Size len;
 					if (Pg_sqlite_split_keyval(interp, row, &columns, nColumns, sepString, columnNames, unknownObj) != TCL_OK) {
 						returnCode = TCL_ERROR;
 						break;

--- a/generic/pgtclSqlite.h
+++ b/generic/pgtclSqlite.h
@@ -2,7 +2,8 @@
 #define PGTCLSQLITE_H
 
 #include <tcl.h>
+#include "pgtclCompat.h"
 extern int Pg_sqlite(
-  ClientData cData, Tcl_Interp *interp, int objc, Tcl_Obj *CONST objv[]);
+  ClientData cData, Tcl_Interp *interp, int objc, Tcl_Obj *const objv[]);
 
 #endif

--- a/generic/tokenize.c
+++ b/generic/tokenize.c
@@ -455,16 +455,16 @@ int Pg_sqlite3GetToken(const char *z, enum sqltoken *tokenType){
   return i;
 }
 
-extern int array_to_utf8(Tcl_Interp *interp, const char **paramValues, int *paramLengths, int nParams, const char **bufferPtr);
+extern int array_to_utf8(Tcl_Interp *interp, const char **paramValues, Tcl_Size *paramLengths, int nParams, const char **bufferPtr);
 
-int handle_substitutions(Tcl_Interp *interp, const char *sql, char **newSqlPtr, const char ***replacementArrayPtr, int *replacementArrayLengthPtr, const char **bufferPtr)
+int handle_substitutions(Tcl_Interp *interp, const char *sql, char **newSqlPtr, const char ***replacementArrayPtr, Tcl_Size *replacementArrayLengthPtr, const char **bufferPtr)
 {
 	// Worst possible case, :a mapping to $99999 at the end of a really long string
 	char *newSql = ckalloc(strlen(sql)*3+1);
 	// Worst possible case? the sql is nothing but ":varname" and they're all one character names. This
 	// will still be big enough.
 	const char **replacementArray = (const char **)ckalloc((strlen(sql)/2) * (sizeof *replacementArray));
-	int *lengthArray = (int *)ckalloc((strlen(sql)/2) * sizeof (int));
+	Tcl_Size *lengthArray = (Tcl_Size *)ckalloc((strlen(sql)/2) * sizeof (Tcl_Size));
 
 	const char *p;
 	char *q;
@@ -485,7 +485,7 @@ int handle_substitutions(Tcl_Interp *interp, const char *sql, char **newSqlPtr, 
 			}
 			case TK_TCLVAR: {
 				char *nameBuf = ckalloc(len);
-				int stringLength;
+				Tcl_Size stringLength;
 				Tcl_Obj *varObj = NULL;
 				int i;
 				int skip = 1;

--- a/generic/tokenize.h
+++ b/generic/tokenize.h
@@ -5,6 +5,7 @@
 */
 #include <ctype.h>
 #include <tcl.h>
+#include "pgtclCompat.h"
 
 enum sqltoken {
 TK_BITAND, TK_BITNOT, TK_BITOR, TK_BLOB, TK_COMMA, TK_CONCAT, TK_DOT, TK_EQ, TK_FLOAT, TK_GE,
@@ -14,7 +15,7 @@ TK_CAST, TK_HASH
 };
 
 int Pg_sqlite3GetToken(const char *z, enum sqltoken *tokenType);
-int handle_substitutions(Tcl_Interp *interp, const char *sql, char **newSqlPtr, const char ***replacementArrayPtr, int *replacementArrayLengthPtr, const char **bufferPtr);
+int handle_substitutions(Tcl_Interp *interp, const char *sql, char **newSqlPtr, const char ***replacementArrayPtr, Tcl_Size *replacementArrayLengthPtr, const char **bufferPtr);
 
 #define sqlite3Isdigit(x) isdigit(x)
 #define sqlite3Isspace(x) isspace(x)


### PR DESCRIPTION
Problem
-------
pgtcl fails to compile against Tcl 9.0 headers (e.g. building against PostgreSQL 19 / recent Fedora-Rawhide-style toolchains that ship Tcl 9). The build aborts with dozens of

    error: expected ';', ',' or ')' before 'objv'

and, once that is fixed, a second wave of

    error: passing argument N of '...' from incompatible pointer type
    note: expected 'Tcl_Size *' but argument is of type 'int *'

and one instance of

    error: storage size of 'cmd_info' isn't known

After those are resolved, the build succeeds but leaves a small number of warnings, also fixed by this patch (see item 6 below).

Root cause
----------
Tcl 9.0 removed two long-deprecated Tcl-8.0-era compatibility shims that pgtcl's sources still relied on:

  1. The `CONST` / `CONST84` / `CONST86` macros are gone. Every `Tcl_Obj *CONST objv[]` (and one `CONST char *`) in pgtcl no longer parses, since `CONST` is now just an unknown identifier sitting where the compiler expects a parameter name. Plain `const` has been the correct, portable spelling since Tcl 8.4, so this patch simply spells it that way everywhere.

  2. String/list lengths and element counts that used to be returned via "int *" out-parameters (Tcl_GetStringFromObj, Tcl_GetByteArrayFromObj, Tcl_ListObjGetElements, Tcl_ListObjLength, ...) now use the new, pointer-width `Tcl_Size` type. Every local variable, struct field and helper-function parameter in pgtcl that receives one of these lengths has been changed to `Tcl_Size`, with a small compatibility header (generic/pgtclCompat.h) providing a `typedef int Tcl_Size;` fallback for Tcl 8.x, which doesn't define this type at all. This mirrors the migration path documented by the Tcl maintainers: https://www.tcl-lang.org/doc/howto/size_t.html

  3. `struct Tcl_CmdInfo` is used in two places in pgtclSqlite.c, but `Tcl_CmdInfo` has always actually been a typedef, not a tagged struct; older Tcl headers happened to also declare a struct tag of the same name; the anonymous-struct-only header in newer Tcl no longer does, so the `struct` keyword must be dropped.

  4. One additional, previously-hidden bug surfaces once the above parse errors are fixed: Pg_lo_read() passed the long-obsolete `TCL_PARSE_PART1` flag to Tcl_ObjSetVar2(). That flag was removed in Tcl 9.0. Tcl_ObjSetVar2() has parsed array syntax ("name(index)") in part1 automatically for a very long time regardless of this flag, so it is simply dropped; behaviour is unchanged on every supported Tcl version.

  5. A handful of `ckfree(some_const_char_ptr)` calls relied on the old `ckfree(x)` macro casting its argument to `(char *)` internally. Tcl 9.0's non-debug `ckfree` is a bare `#define ckfree Tcl_Free` with no cast, so these now need an explicit `(void *)` cast at the call site to avoid a "discards const qualifier" warning.

  6. Three warnings remained after the above (all pre-existing, just never previously reached because the build died earlier):

       - pgtclId.c: getresid() and PgGetConnByResultId() take a
         `const char *` handle string, then temporarily NUL the last '.'
         in place (and restore it) to split the connection id from the
         result id. `mark = strrchr(id, '.')` assigned the result
         straight into a `char *`, which some toolchains flag as
         discarding the const qualifier since `id` is const. The
         temporary in-place mutation itself is unchanged (it's the
         existing, intentional behaviour); the cast is now explicit:
         `mark = (char *) strrchr(id, '.');`

       - pgtclCmds.c: Pg_select() declared `int tuplesProcessed = 0;`
         and incremented it once per row, but never read it anywhere.
         The `-count var` feature that this looks like it was meant to
         feed is actually driven by a separate `numTuples`/`tuplesVarObj`
         pair a few lines away, so `tuplesProcessed` was simply dead
         code left over from an earlier version. It has been removed
         (declaration + increment); this does not change any observable
         behaviour, since its value was never used.

None of this changes pgtcl's behaviour on any currently supported Tcl version -- it only replaces removed/renamed compatibility spellings with their modern equivalents, and drops one genuinely-unused variable.

Hacked by Claude, tested by me.

Per: https://github.com/pgdg-packaging/pgdg-rpms/issues/213